### PR TITLE
Removed posting a HistoricalLocation from createEntities

### DIFF
--- a/src/main/java/org/opengis/cite/sta10/createUpdateDelete/Capability2Tests.java
+++ b/src/main/java/org/opengis/cite/sta10/createUpdateDelete/Capability2Tests.java
@@ -195,17 +195,6 @@ public class Capability2Tests {
             long obsId3 = entity.getLong(ControlInformation.ID);
             observationIds.add(obsId3);
             checkAutomaticInsertionOfFOI(obsId2, locationEntity, automatedFOIId);
-
-            /** HistoricalLocation **/
-            urlParameters = "{\n" +
-                    "  \"time\": \"2015-03-01T00:40:00.000Z\",\n" +
-                    "  \"Thing\":{\"@iot.id\": " + thingId + "},\n" +
-                    "  \"Locations\": [{\"@iot.id\": " + locationId + "}]  \n" +
-                    "}";
-            entity = postEntity(EntityType.HISTORICAL_LOCATION, urlParameters);
-            long histLocId = entity.getLong(ControlInformation.ID);
-            historicalLocationIds.add(histLocId);
-
         } catch (JSONException e) {
             e.printStackTrace();
             Assert.fail("An Exception occurred during testing!:\n" + e.getMessage());


### PR DESCRIPTION
Removed posting a HistoricalLocation from createEntities, this is not allowed according to the SensorThings spec