### PR TITLE
* Compare properties that are not String using their Comparable inter…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,10 @@
       <artifactId>httpclient</artifactId>
       <version>4.5</version>
     </dependency>
+    <dependency>
+      <groupId>joda-time</groupId>
+      <artifactId>joda-time</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/org/opengis/cite/sta10/filteringExtension/Capability3Tests.java
+++ b/src/main/java/org/opengis/cite/sta10/filteringExtension/Capability3Tests.java
@@ -1,5 +1,13 @@
 package org.opengis.cite.sta10.filteringExtension;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import org.joda.time.DateTime;
+import org.joda.time.format.ISODateTimeFormat;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -10,12 +18,6 @@ import org.testng.ITestContext;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-
 
 /**
  * Includes various tests of "A.2 Filtering Extension" Conformance class.
@@ -129,9 +131,9 @@ public class Capability3Tests {
     }
 
     /**
-     * This method is testing $top query option.
-     * It tests $top for collection of entities with 1 level and 2 levels resource path.
-     * It also tests @iot.nextLink with regard to $top.
+     * This method is testing $top query option. It tests $top for collection of
+     * entities with 1 level and 2 levels resource path. It also tests
+     * {@literal @iot.nextLink} with regard to $top.
      */
     @Test(description = "GET Entities with $top", groups = "level-3")
     public void readEntitiesWithTopQO() {
@@ -155,9 +157,9 @@ public class Capability3Tests {
     }
 
     /**
-     * This method is testing $skip query option.
-     * It tests $skip for collection of entities with 1 level and 2 levels resource path.
-     * It also tests @iot.nextLink with regard to $skip.
+     * This method is testing $skip query option. It tests $skip for collection
+     * of entities with 1 level and 2 levels resource path. It also tests
+     * {@literal @iot.nextLink} with regard to $skip.
      */
     @Test(description = "GET Entities with $skip", groups = "level-3")
     public void readEntitiesWithSkipQO() {
@@ -230,11 +232,15 @@ public class Capability3Tests {
     }
 
     /**
-     * This method is testing $filter query option for {@literal <, <=, =, >=, >} on properties.
-     * It tests $filter for collection of entities with 1 level and 2 levels resource path.
+     * This method is testing $filter query option for
+     * {@literal <, <=, =, >=, >} on properties. It tests $filter for collection
+     * of entities with 1 level and 2 levels resource path.
+     *
+     * @throws java.io.UnsupportedEncodingException Should not happen, UTF-8
+     * should always be supported.
      */
     @Test(description = "GET Entities with $filter", groups = "level-3")
-    public void readEntitiesWithFilterQO() {
+    public void readEntitiesWithFilterQO() throws UnsupportedEncodingException {
         checkFilterForEntityType(EntityType.THING);
         checkFilterForEntityType(EntityType.LOCATION);
         checkFilterForEntityType(EntityType.HISTORICAL_LOCATION);
@@ -254,8 +260,9 @@ public class Capability3Tests {
     }
 
     /**
-     * This method is testing the correct priority of the query options.
-     * It uses $count, $top, $skip, $orderby, and $filter togther and check the priority in result.
+     * This method is testing the correct priority of the query options. It uses
+     * $count, $top, $skip, $orderby, and $filter togther and check the priority
+     * in result.
      */
     @Test(description = "Check priotity of query options", groups = "level-3")
     public void checkQueriesPriorityOrdering() {
@@ -1144,7 +1151,8 @@ public class Capability3Tests {
                 }
                 selectedProperties = new ArrayList<>();
                 for (String property : properties) {
-                    selectedProperties.add(property);response = getEntities(entityType, id, relationEntityType, selectedProperties, null);
+                    selectedProperties.add(property);
+                    response = getEntities(entityType, id, relationEntityType, selectedProperties, null);
                     checkEntitiesAllAspectsForSelectResponse(relationEntityType, response, selectedProperties);
                 }
             }
@@ -1342,31 +1350,31 @@ public class Capability3Tests {
                             } else {
                                 expandedEntityArray = entity.getJSONArray(relation);
                             }
-                        }catch (JSONException e){
+                        } catch (JSONException e) {
                             Assert.fail("Entity type \"" + entityType + "\" does not have expanded relation Correctly: \"" + relation + "\".");
                         }
-                            checkPropertiesForEntityArray(getEntityTypeFor(relation), expandedEntityArray, new ArrayList<String>(Arrays.asList(EntityProperties.getPropertiesListFor(relation))));
-                            if(listContainsString(expandedRelations, "/")) {
-                                String[] secondLevelRelations = EntityRelations.getRelationsListFor(relation);
-                                JSONObject expandedEntity = expandedEntityArray.getJSONObject(0);
-                                for (String secondLeveleRelation : secondLevelRelations) {
-                                    if (listContainsString(expandedRelations, relation+"/"+secondLeveleRelation)) {
+                        checkPropertiesForEntityArray(getEntityTypeFor(relation), expandedEntityArray, new ArrayList<String>(Arrays.asList(EntityProperties.getPropertiesListFor(relation))));
+                        if (listContainsString(expandedRelations, "/")) {
+                            String[] secondLevelRelations = EntityRelations.getRelationsListFor(relation);
+                            JSONObject expandedEntity = expandedEntityArray.getJSONObject(0);
+                            for (String secondLeveleRelation : secondLevelRelations) {
+                                if (listContainsString(expandedRelations, relation + "/" + secondLeveleRelation)) {
 
-                                        expandedEntityArray = null;
-                                        try {
-                                            if (secondLeveleRelation.charAt(secondLeveleRelation.length() - 1) != 's' && !secondLeveleRelation.equals("FeaturesOfInterest")) {
-                                                expandedEntityArray = new JSONArray();
-                                                expandedEntityArray.put(expandedEntity.getJSONObject(secondLeveleRelation));
-                                            } else {
-                                                expandedEntityArray = expandedEntity.getJSONArray(secondLeveleRelation);
-                                            }
-                                        } catch (JSONException e){
-                                            Assert.fail("Entity type \"" + entityType + "\" does not have expanded relation Correctly: \"" + relation + "/"+secondLeveleRelation+"\".");
+                                    expandedEntityArray = null;
+                                    try {
+                                        if (secondLeveleRelation.charAt(secondLeveleRelation.length() - 1) != 's' && !secondLeveleRelation.equals("FeaturesOfInterest")) {
+                                            expandedEntityArray = new JSONArray();
+                                            expandedEntityArray.put(expandedEntity.getJSONObject(secondLeveleRelation));
+                                        } else {
+                                            expandedEntityArray = expandedEntity.getJSONArray(secondLeveleRelation);
                                         }
-                                        checkPropertiesForEntityArray(getEntityTypeFor(secondLeveleRelation), expandedEntityArray, new ArrayList<String>(Arrays.asList(EntityProperties.getPropertiesListFor(secondLeveleRelation))));
+                                    } catch (JSONException e) {
+                                        Assert.fail("Entity type \"" + entityType + "\" does not have expanded relation Correctly: \"" + relation + "/" + secondLeveleRelation + "\".");
                                     }
+                                    checkPropertiesForEntityArray(getEntityTypeFor(secondLeveleRelation), expandedEntityArray, new ArrayList<String>(Arrays.asList(EntityProperties.getPropertiesListFor(secondLeveleRelation))));
                                 }
                             }
+                        }
                     }
                 } else {
                     try {
@@ -1653,24 +1661,27 @@ public class Capability3Tests {
 
     /**
      * This helper method is checking $filter for a collection.
-     * @param entityType  Entity type from EntityType enum list
+     *
+     * @param entityType Entity type from EntityType enum list
+     * @throws java.io.UnsupportedEncodingException Should not happen, UTF-8
+     * should always be supported.
      */
-    private void checkFilterForEntityType(EntityType entityType){
+    private void checkFilterForEntityType(EntityType entityType) throws UnsupportedEncodingException {
         String[] properties = EntityProperties.getPropertiesListFor(entityType);
         List<String> filteredProperties;
-        List<String> samplePropertyValues;
+        List<Comparable> samplePropertyValues;
         for (int i = 0; i < properties.length; i++) {
-            filteredProperties=new ArrayList<>();
+            filteredProperties = new ArrayList<>();
             samplePropertyValues = new ArrayList<>();
             String property = properties[i];
             filteredProperties.add(property);
-            if(property.equals("location") || property.equals("feature") || property.equals("unitOfMeasurement")){
+            if (property.equals("location") || property.equals("feature") || property.equals("unitOfMeasurement")) {
                 continue;
             }
-            String propertyValue = EntityPropertiesSampleValue.getPropertyValueFor(entityType, i);
+            Comparable propertyValue = EntityPropertiesSampleValue.getPropertyValueFor(entityType, i);
             samplePropertyValues.add(propertyValue);
 
-            propertyValue = propertyValue.replaceAll(" ","%20");
+            propertyValue = URLEncoder.encode(propertyValue.toString(), "UTF-8");
             String urlString = ServiceURLBuilder.buildURLString(rootUri, entityType, -1, null, "?$filter=" + property + "%20lt%20" + propertyValue);
             Map responseMap = HTTPMethods.doGet(urlString);
             String response = responseMap.get("response").toString();
@@ -1700,9 +1711,12 @@ public class Capability3Tests {
 
     /**
      * This helper method is checking $filter for 2 level of entities.
-     * @param entityType  Entity type from EntityType enum list
+     *
+     * @param entityType Entity type from EntityType enum list
+     * @throws java.io.UnsupportedEncodingException Should not happen, UTF-8
+     * should always be supported.
      */
-    private void checkFilterForEntityTypeRelations(EntityType entityType){
+    private void checkFilterForEntityTypeRelations(EntityType entityType) throws UnsupportedEncodingException {
         String[] relations = EntityRelations.getRelationsListFor(entityType);
         String urlString = ServiceURLBuilder.buildURLString(rootUri, entityType, -1, null, null);
         Map<String, Object> responseMap = HTTPMethods.doGet(urlString);
@@ -1733,7 +1747,7 @@ public class Capability3Tests {
 
             String[] properties = EntityProperties.getPropertiesListFor(relationEntityType);
             List<String> filteredProperties;
-            List<String> samplePropertyValues;
+            List<Comparable> samplePropertyValues;
             for (int i = 0; i < properties.length; i++) {
                 filteredProperties = new ArrayList<>();
                 samplePropertyValues = new ArrayList<>();
@@ -1742,10 +1756,10 @@ public class Capability3Tests {
                 if (property.equals("location") || property.equals("feature") || property.equals("unitOfMeasurement")) {
                     continue;
                 }
-                String propertyValue = EntityPropertiesSampleValue.getPropertyValueFor(relationEntityType, i);
+                Comparable propertyValue = EntityPropertiesSampleValue.getPropertyValueFor(relationEntityType, i);
                 samplePropertyValues.add(propertyValue);
 
-                propertyValue = propertyValue.replaceAll(" ", "%20");
+                propertyValue = URLEncoder.encode(propertyValue.toString(), "UTF-8");
                 urlString = ServiceURLBuilder.buildURLString(rootUri, entityType, id, relationEntityType, "?$filter=" + property + "%20lt%20" + propertyValue);
                 responseMap = HTTPMethods.doGet(urlString);
                 response = responseMap.get("response").toString();
@@ -1776,43 +1790,52 @@ public class Capability3Tests {
 
     /**
      * This method is checking the properties of the filtered collection
+     *
      * @param response The response to be checked
      * @param properties List of filtered properties
      * @param values List of values for filtered properties
      * @param operator The operator of the filter
      */
-    private void checkPropertiesForFilter(String response, List<String> properties, List<String> values, int operator){
+    private void checkPropertiesForFilter(String response, List<String> properties, List<Comparable> values, int operator) {
         try {
             JSONObject entities = new JSONObject(response);
             JSONArray entityArray = entities.getJSONArray("value");
             for (int i = 0; i < entityArray.length(); i++) {
                 JSONObject entity = entityArray.getJSONObject(i);
                 for (int j = 0; j < properties.size(); j++) {
-                    String propertyValue = null;
+                    Object propertyValue = "";
                     try {
-                        propertyValue = entity.get(properties.get(j)).toString();
-                    } catch (JSONException e){
-                        Assert.fail("The entity does not have property "+properties.get(j));
+                        propertyValue = entity.get(properties.get(j));
+                    } catch (JSONException e) {
+                        Assert.fail("The entity does not have property " + properties.get(j));
                     }
-                    String value = values.get(j);
-                    if(value.charAt(0)=='\''){
-                        value = value.substring(1,value.length()-1);
+                    if (propertyValue == null) {
+                        Assert.fail("The entity has null value for property " + properties.get(j));
                     }
-                    switch (operator){
+                    Comparable value = values.get(j);
+                    if (value instanceof String && ((String) value).charAt(0) == '\'') {
+                        String sValue = (String) value;
+                        value = sValue.substring(1, sValue.length() - 1);
+                    }
+                    if (value instanceof DateTime) {
+                        propertyValue = ISODateTimeFormat.dateTime().parseDateTime(propertyValue.toString());
+                    }
+                    int result = value.compareTo(propertyValue);
+                    switch (operator) {
                         case -2:
-                            Assert.assertTrue(propertyValue.compareTo(value)<0,properties.get(j)+" should be less than "+value+". But the property value is "+propertyValue);
+                            Assert.assertTrue(result > 0, properties.get(j) + " should be less than " + value + ". But the property value is " + propertyValue);
                             break;
                         case -1:
-                            Assert.assertTrue(propertyValue.compareTo(value)<=0,properties.get(j)+" should be less than or equal to "+value+". But the property value is "+propertyValue);
+                            Assert.assertTrue(result >= 0, properties.get(j) + " should be less than or equal to " + value + ". But the property value is " + propertyValue);
                             break;
                         case 0:
-                            Assert.assertTrue(propertyValue.compareTo(value)==0,properties.get(j)+" should be equal to than "+value+". But the property value is "+propertyValue);
+                            Assert.assertTrue(result == 0, properties.get(j) + " should be equal to than " + value + ". But the property value is " + propertyValue);
                             break;
                         case 1:
-                            Assert.assertTrue(propertyValue.compareTo(value)>=0,properties.get(j)+" should be greate than or equal to "+value+". But the property value is "+propertyValue);
+                            Assert.assertTrue(result <= 0, properties.get(j) + " should be greate than or equal to " + value + ". But the property value is " + propertyValue);
                             break;
                         case 2:
-                            Assert.assertTrue(propertyValue.compareTo(value)>0,properties.get(j)+" should be greater than "+value+". But the property value is "+propertyValue);
+                            Assert.assertTrue(result < 0, properties.get(j) + " should be greater than " + value + ". But the property value is " + propertyValue);
                             break;
                     }
                 }

--- a/src/main/java/org/opengis/cite/sta10/util/EntityPropertiesSampleValue.java
+++ b/src/main/java/org/opengis/cite/sta10/util/EntityPropertiesSampleValue.java
@@ -1,10 +1,14 @@
 package org.opengis.cite.sta10.util;
 
+import org.joda.time.format.ISODateTimeFormat;
+
 /**
- * Provides list of sample values for each property of each entity for testing $filter.
- * These values are the same as the properties of one of the entities that is created in pre-test.
+ * Provides list of sample values for each property of each entity for testing
+ * $filter. These values are the same as the properties of one of the entities
+ * that is created in pre-test.
  */
 public class EntityPropertiesSampleValue {
+
     /**
      * Sample properties for Thing entity.
      */
@@ -12,11 +16,11 @@ public class EntityPropertiesSampleValue {
     /**
      * Sample properties for Location entity.
      */
-    public static final String[] LOCATION_PROPERTIES_Values = {"'location 2'", "'http://example.org/location_types/GeoJSON'", "location" };
+    public static final String[] LOCATION_PROPERTIES_Values = {"'location 2'", "'application/vnd.geo+json'", "location"};
     /**
      * Sample properties for HistoricalLocation entity.
      */
-    public static final String[] HISTORICAL_LOCATION_PROPERTIES_Values = {"'2015-10-14T21:30:00.104Z'"};
+    public static final Comparable[] HISTORICAL_LOCATION_PROPERTIES_Values = {ISODateTimeFormat.dateTime().parseDateTime("2015-10-14T21:30:00.104Z")};
     /**
      * Sample properties for Datastream entity.
      */
@@ -28,15 +32,18 @@ public class EntityPropertiesSampleValue {
     /**
      * Sample properties for ObservedProperty entity.
      */
-    public static final String[] OBSERVED_PROPETY_PROPERTIES_Values = { "'Luminous Flux'", "'http://www.qudt.org/qudt/owl/1.0.0/quantity/Instances.html/LuminousFlux'", "'observedProperty 1'"};
+    public static final String[] OBSERVED_PROPETY_PROPERTIES_Values = {"'Luminous Flux'", "'http://www.qudt.org/qudt/owl/1.0.0/quantity/Instances.html/LuminousFlux'", "'observedProperty 1'"};
     /**
      * Sample properties for Observation entity.
      */
-    public static final String[] OBSERVATION_PROPERTIES_Values = {"'2015-03-02T00:00:00.000Z'","'2'","'2015-03-02T00:00:00.000Z'"};
+    public static final Comparable[] OBSERVATION_PROPERTIES_Values = {
+        ISODateTimeFormat.dateTime().parseDateTime("2015-03-02T00:00:00.000Z"),
+        Integer.valueOf(2),
+        ISODateTimeFormat.dateTime().parseDateTime("2015-03-02T00:00:00.000Z")};
     /**
      * Sample properties for FeatureOfInterest entity.
      */
-    public static final String[] FEATURE_OF_INTEREST_PROPERTIES_Values = {"'Generated using location details: location 1'", "'http://example.org/location_types/GeoJSON'", "feature" };
+    public static final String[] FEATURE_OF_INTEREST_PROPERTIES_Values = {"'Generated using location details: location 1'", "'application/vnd.geo+json'", "feature"};
 
 
     /**
@@ -45,10 +52,8 @@ public class EntityPropertiesSampleValue {
      * @param index The index of the requested properties in the properties list of the entityType
      * @return The sample value from the properties list of the given "entityType" positioned in location "index" in the list
      */
-    public static String getPropertyValueFor(EntityType entityType, int index) {
-        switch (entityType)
-
-        {
+    public static Comparable getPropertyValueFor(EntityType entityType, int index) {
+        switch (entityType) {
             case THING:
                 return THING_PROPERTIES_Values[index];
             case LOCATION:


### PR DESCRIPTION
* Compare properties that are not String using their Comparable interface instead of comparing everything as a String.

This fixes https://github.com/opengeospatial/ets-sta10/issues/10
This also compares result values using their numeric value instead of their string value.