### PR TITLE
MQTT Subscribe Tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,17 @@
   </properties>
 
   <dependencies>
+	<dependency>
+		<groupId>org.eclipse.paho</groupId>
+		<artifactId>org.eclipse.paho.client.mqttv3</artifactId>
+		<version>1.0.2</version>
+	</dependency>
     <dependency>
+
+
+
+
+
       <groupId>org.opengis.cite.teamengine</groupId>
       <artifactId>teamengine-spi</artifactId>
     </dependency>
@@ -86,6 +96,11 @@
     <dependency>
       <groupId>joda-time</groupId>
       <artifactId>joda-time</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>1.1.3</version>
     </dependency>
   </dependencies>
 

--- a/src/main/java/org/opengis/cite/sta10/SuiteAttribute.java
+++ b/src/main/java/org/opengis/cite/sta10/SuiteAttribute.java
@@ -10,7 +10,7 @@ import org.w3c.dom.Document;
 @SuppressWarnings("rawtypes")
 public enum SuiteAttribute {
 
-	/**
+    /**
      * A client component for interacting with HTTP endpoints.
      */
     CLIENT("httpClient", Client.class),
@@ -22,7 +22,16 @@ public enum SuiteAttribute {
      * An integer denoting the conformance level to check. A given conformance
      * level includes all lower levels.
      */
-    LEVEL("level", Integer.class);
+    LEVEL("level", Integer.class),
+    /**
+     * Address of the MQTT server including port (e.g. tcp://localhost:1883)
+     */
+    MQTT_SERVER("mqttServer", String.class),
+    /**
+     * Timeout used to wait for messages on MQTT in milliseconds (e.g. 3000
+     * equals 3 seconds)
+     */
+    MQTT_TIMEOUT("mqttTimeout", Long.class);
 
     private final Class attrType;
     private final String attrName;

--- a/src/main/java/org/opengis/cite/sta10/TestRunArg.java
+++ b/src/main/java/org/opengis/cite/sta10/TestRunArg.java
@@ -14,7 +14,16 @@ public enum TestRunArg {
      * An integer value denoting the conformance level to check. A given
      * conformance level includes all lower levels.
      */
-    ICS;
+    ICS,
+    /**
+     * Address of the MQTT server including port (e.g. tcp://localhost:1883)
+     */
+    MQTT_SERVER,
+    /**
+     * Timeout used to wait for messages on MQTT in milliseconds (e.g. 3000
+     * equals 3 seconds)
+     */
+    MQTT_TIMEOUT;
 
     @Override
     public String toString() {

--- a/src/main/java/org/opengis/cite/sta10/receiveUpdatesViaMQTT/Capability8Test.java
+++ b/src/main/java/org/opengis/cite/sta10/receiveUpdatesViaMQTT/Capability8Test.java
@@ -1,0 +1,504 @@
+/*
+ * Copyright 2016 Open Geospatial Consortium.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opengis.cite.sta10.receiveUpdatesViaMQTT;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Queue;
+import java.util.concurrent.Callable;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.opengis.cite.sta10.SuiteAttribute;
+import org.opengis.cite.sta10.util.EntityProperties;
+import org.opengis.cite.sta10.util.EntityRelations;
+import org.opengis.cite.sta10.util.EntityType;
+import org.testng.Assert;
+import org.testng.ITestContext;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+/**
+ *
+ * @author jab
+ */
+public class Capability8Test {
+
+    private static final List<EntityType> ENTITY_TYPES_FOR_CREATE = Arrays.asList(
+            EntityType.THING,
+            EntityType.LOCATION,
+            EntityType.SENSOR,
+            EntityType.OBSERVED_PROPERTY,
+            EntityType.FEATURE_OF_INTEREST,
+            EntityType.DATASTREAM,
+            EntityType.OBSERVATION,
+            EntityType.HISTORICAL_LOCATION);
+    private static final List<EntityType> ENTITY_TYPES_FOR_DEEP_INSERT = Arrays.asList(
+            EntityType.THING,
+            EntityType.DATASTREAM,
+            EntityType.OBSERVATION);
+    private static final List<EntityType> ENTITY_TYPES_FOR_DELETE = Arrays.asList(
+            EntityType.OBSERVATION,
+            EntityType.FEATURE_OF_INTEREST,
+            EntityType.DATASTREAM,
+            EntityType.SENSOR,
+            EntityType.OBSERVED_PROPERTY,
+            EntityType.HISTORICAL_LOCATION,
+            EntityType.LOCATION,
+            EntityType.THING);
+
+    private EntityHelper entityHelper;
+    private MqttHelper mqttHelper;
+    private final Map<EntityType, Long> ids = new HashMap<>();
+    private String rootUri;
+
+    @Test(description = "Subcribe to EntitySet and insert Entity", groups = "level-8", priority = 1)
+    public void checkSubscribeToEntitySetInsert() {
+        ENTITY_TYPES_FOR_CREATE.stream().forEach((entityType) -> {
+            MqttBatchResult<Long> result = mqttHelper.executeRequests(getInsertEntityAction(entityType), MqttHelper.getTopic(entityType));
+            ids.put(entityType, result.getActionResult());
+            Assert.assertTrue(jsonEqualsWithLinkResolving(entityHelper.getEntity(entityType, result.getActionResult()), result.getMessages().values().iterator().next(), MqttHelper.getTopic(entityType)));
+        });
+    }
+
+    @Test(description = "Subcribe to EntitySet and update (PATCH) Entity", groups = "level-8", priority = 3)
+    public void checkSubscribeToEntitySetUpdatePATCH() {
+        deleteCreatedEntities();
+        createEntities();
+        ENTITY_TYPES_FOR_CREATE.stream().forEach((entityType) -> {
+            MqttBatchResult<JSONObject> result = mqttHelper.executeRequests(getUpdatePatchEntityAction(entityType), MqttHelper.getTopic(entityType));
+            Assert.assertTrue(jsonEqualsWithLinkResolving(result.getActionResult(), result.getMessages().values().iterator().next(), MqttHelper.getTopic(entityType)));
+        });
+    }
+
+    @Test(description = "Subcribe to EntitySet and update (PUT) Entity", groups = "level-8", priority = 2)
+    public void checkSubscribeToEntitySetUpdatePUT() {
+        ENTITY_TYPES_FOR_CREATE.stream().forEach((entityType) -> {
+            MqttBatchResult<JSONObject> result = mqttHelper.executeRequests(getUpdatePutEntityAction(entityType), MqttHelper.getTopic(entityType));
+            Assert.assertTrue(jsonEqualsWithLinkResolving(result.getActionResult(), result.getMessages().values().iterator().next(), MqttHelper.getTopic(entityType)));
+        });
+    }
+
+    @Test(description = "Subcribe to EntitySet with multiple $select and insert Entity", groups = "level-8", priority = 8)
+    public void checkSubscribeToEntitySetWithMultipleSelectInsert() {
+        deleteCreatedEntities();
+        ENTITY_TYPES_FOR_CREATE.stream().forEach((entityType) -> {
+            List<String> selectedProperties = getSelectedProperties(entityType);
+            MqttBatchResult<Long> result = mqttHelper.executeRequests(getInsertEntityAction(entityType), MqttHelper.getTopic(entityType, selectedProperties));
+            ids.put(entityType, result.getActionResult());
+            JSONObject entity = entityHelper.getEntity(entityType, result.getActionResult());
+            filterEntity(entity, selectedProperties);
+            Assert.assertTrue(jsonEqualsWithLinkResolving(entity, result.getMessages().values().iterator().next(), MqttHelper.getTopic(entityType, selectedProperties)));
+        });
+    }
+
+    @Test(description = "Subcribe to EntitySet with multiple $select and update (PATCH) Entity", groups = "level-8", priority = 10)
+    public void checkSubscribeToEntitySetWithMultipleSelectUpdatePATCH() {
+        deleteCreatedEntities();
+        createEntities();
+        ENTITY_TYPES_FOR_CREATE.stream().forEach((entityType) -> {
+            List<String> selectedProperties = getSelectedProperties(entityType);
+
+            Map<String, Object> changes = entityHelper.getEntityChanges(entityType, selectedProperties);
+            MqttBatchResult<JSONObject> result = mqttHelper.executeRequests(
+                    () -> {
+                        return entityHelper.patchEntity(entityType, changes, ids.get(entityType));
+                    },
+                    MqttHelper.getTopic(entityType, selectedProperties));
+            Assert.assertTrue(jsonEqualsWithLinkResolving(new JSONObject(changes), result.getMessages().values().iterator().next(), MqttHelper.getTopic(entityType, selectedProperties)));
+        });
+    }
+
+    @Test(description = "Subcribe to EntitySet with multiple $select and update (PUT) Entity", groups = "level-8", priority = 9)
+    public void checkSubscribeToEntitySetWithMultipleSelectUpdatePUT() {
+        ENTITY_TYPES_FOR_CREATE.stream().forEach((entityType) -> {
+            List<String> selectedProperties = getSelectedProperties(entityType);
+
+            Map<String, Object> changes = entityHelper.getEntityChanges(entityType, selectedProperties);
+            MqttBatchResult<JSONObject> result = mqttHelper.executeRequests(
+                    () -> {
+                        return entityHelper.putEntity(entityType, changes, ids.get(entityType));
+                    },
+                    MqttHelper.getTopic(entityType, selectedProperties));
+            Assert.assertTrue(jsonEqualsWithLinkResolving(new JSONObject(changes), result.getMessages().values().iterator().next(), MqttHelper.getTopic(entityType, selectedProperties)));
+        });
+    }
+
+    @Test(description = "Subcribe to EntitySet via relative topic", groups = "level-8", priority = 8)
+    public void checkSubscribeToEntitySetWithRelativeTopicUpdatePUT() {
+        deleteCreatedEntities();
+        createEntities();
+        ENTITY_TYPES_FOR_CREATE.stream().forEach((entityType) -> {
+            List<String> relativeTopics = MqttHelper.getRelativeTopicsForEntitySet(entityType, ids);
+            if (!(relativeTopics.isEmpty())) {
+                MqttBatchResult<JSONObject> result = mqttHelper.executeRequests(
+                        getUpdatePutEntityAction(entityType),
+                        relativeTopics.toArray(new String[relativeTopics.size()]));
+                result.getMessages().entrySet().stream().forEach((entry) -> {
+                    try {
+                        // coudl return multiple results so make sure we only get the latest
+                        JSONObject expectedResult = entityHelper.getEntity(entry.getKey() + "?$orderby=id%20desc&$top=1").getJSONArray("value").getJSONObject(0);
+                        Assert.assertTrue(jsonEqualsWithLinkResolving(expectedResult, entry.getValue(), entry.getKey()));
+                    } catch (JSONException ex) {
+                        Assert.fail("Could not get expected result for MQTT subscription from server", ex);
+                    }
+                });
+            }
+        });
+    }
+
+    @Test(description = "Subcribe to multiple EntitySets and deep insert multiple entites", groups = "level-8", priority = 8)
+    public void checkSubscribeToEntitySetsWithDeepInsert() {
+        deleteCreatedEntities();
+        ENTITY_TYPES_FOR_DEEP_INSERT.stream().forEach((EntityType entityType) -> {
+            DeepInsertInfo deepInsertInfo = entityHelper.getDeepInsertInfo(entityType);
+            List<String> topics = new ArrayList<>(deepInsertInfo.getSubEntityTypes().size() + 1);
+            topics.add(MqttHelper.getTopic(deepInsertInfo.getEntityType()));
+            deepInsertInfo.getSubEntityTypes().stream().forEach((subType) -> {
+                topics.add(MqttHelper.getTopic(subType));
+            });
+            MqttBatchResult<Long> result = mqttHelper.executeRequests(
+                    getDeepInsertEntityAction(entityType),
+                    topics.toArray(new String[topics.size()]));
+            ids.put(entityType, result.getActionResult());
+            JSONObject entity = entityHelper.getEntity(deepInsertInfo.getEntityType(), result.getActionResult());
+            Optional<JSONObject> rootResult = result.getMessages().entrySet().stream().filter(x -> x.getKey().equals(MqttHelper.getTopic(deepInsertInfo.getEntityType()))).map(x -> x.getValue()).findFirst();
+            if (!rootResult.isPresent()) {
+                Assert.fail("Deep insert MQTT result is missing root entity");
+            }
+            Assert.assertTrue(jsonEqualsWithLinkResolving(entity, rootResult.get(), MqttHelper.getTopic(deepInsertInfo.getEntityType())));
+            deepInsertInfo.getSubEntityTypes().stream().forEach((subType) -> {
+                JSONObject subEntity = getSubEntityByRoot(deepInsertInfo.getEntityType(), result.getActionResult(), subType);
+                Optional<JSONObject> subResult = result.getMessages().entrySet().stream().filter(x -> x.getKey().equals(MqttHelper.getTopic(subType))).map(x -> x.getValue()).findFirst();
+                if (!subResult.isPresent()) {
+                    Assert.fail("Deep insert MQTT result is missing entity " + subEntity.toString());
+                }
+                Assert.assertTrue(jsonEqualsWithLinkResolving(subEntity, subResult.get(), MqttHelper.getTopic(subType)));
+            });
+        });
+    }
+
+    @Test(description = "Subcribe to Entity and update (PATCH) Entity", groups = "level-8", priority = 5)
+    public void checkSubscribeToEntityUpdatePATCH() {
+        deleteCreatedEntities();
+        createEntities();
+        ENTITY_TYPES_FOR_CREATE.stream().forEach((entityType) -> {
+            MqttBatchResult<JSONObject> result = mqttHelper.executeRequests(getUpdatePatchEntityAction(entityType), MqttHelper.getTopic(entityType, ids.get(entityType)));
+            Assert.assertTrue(jsonEqualsWithLinkResolving(result.getActionResult(), result.getMessages().values().iterator().next(), MqttHelper.getTopic(entityType, ids.get(entityType))));
+        });
+    }
+
+    @Test(description = "Subcribe to Entity and update (PUT) Entity", groups = "level-8", priority = 4)
+    public void checkSubscribeToEntityUpdatePUT() {
+        deleteCreatedEntities();
+        createEntities();
+        ENTITY_TYPES_FOR_CREATE.stream().forEach((entityType) -> {
+            MqttBatchResult<JSONObject> result = mqttHelper.executeRequests(getUpdatePutEntityAction(entityType), MqttHelper.getTopic(entityType, ids.get(entityType)));
+            Assert.assertTrue(jsonEqualsWithLinkResolving(result.getActionResult(), result.getMessages().values().iterator().next(), MqttHelper.getTopic(entityType, ids.get(entityType))));
+        });
+    }
+
+    @Test(description = "Subcribe to Entity via relative topic", groups = "level-8", priority = 8)
+    public void checkSubscribeToEntityWithRelativeTopicUpdatePUT() {
+        deleteCreatedEntities();
+        createEntities();
+        ENTITY_TYPES_FOR_CREATE.stream().forEach((entityType) -> {
+            List<String> relativeTopics = MqttHelper.getRelativeTopicsForEntity(entityType, ids);
+            if (!(relativeTopics.isEmpty())) {
+                MqttBatchResult<JSONObject> result = mqttHelper.executeRequests(
+                        getUpdatePutEntityAction(entityType),
+                        relativeTopics.toArray(new String[relativeTopics.size()]));
+                result.getMessages().entrySet().stream().forEach((entry) -> {
+                    JSONObject expectedResult = entityHelper.getEntity(entry.getKey());
+                    Assert.assertTrue(jsonEqualsWithLinkResolving(expectedResult, entry.getValue(), entry.getKey()));
+                });
+            }
+        });
+    }
+
+    @Test(description = "Subcribe to Property and update (PATCH) Entity", groups = "level-8", priority = 7)
+    public void checkSubscribeToPropertyUpdatePATCH() {
+        deleteCreatedEntities();
+        createEntities();
+        ENTITY_TYPES_FOR_CREATE.stream().forEach((entityType) -> {
+            Map<String, Object> changes = entityHelper.getEntityChanges(entityType);
+            for (String property : EntityProperties.getPropertiesListFor(entityType)) {
+                Map<String, Object> propertyChange = new HashMap<>(0);
+                propertyChange.put(property, changes.get(property));
+                MqttBatchResult<JSONObject> result = mqttHelper.executeRequests(
+                        () -> {
+                            return entityHelper.patchEntity(entityType, propertyChange, ids.get(entityType));
+                        },
+                        MqttHelper.getTopic(entityType, ids.get(entityType), property));
+                Assert.assertTrue(jsonEqualsWithLinkResolving(new JSONObject(propertyChange), result.getMessages().values().iterator().next(), MqttHelper.getTopic(entityType, ids.get(entityType), property)));
+            }
+        });
+    }
+
+    @Test(description = "Subcribe to Property and update (PUT) Entity", groups = "level-8", priority = 6)
+    public void checkSubscribeToPropertyUpdatePUT() {
+        deleteCreatedEntities();
+        createEntities();
+        ENTITY_TYPES_FOR_CREATE.stream().forEach((entityType) -> {
+            Map<String, Object> changes = entityHelper.getEntityChanges(entityType);
+            for (String property : EntityProperties.getPropertiesListFor(entityType)) {
+                Map<String, Object> propertyChange = new HashMap<>(0);
+                propertyChange.put(property, changes.get(property));
+                MqttBatchResult<JSONObject> result = mqttHelper.executeRequests(
+                        () -> {
+                            return entityHelper.putEntity(entityType, propertyChange, ids.get(entityType));
+                        },
+                        MqttHelper.getTopic(entityType, ids.get(entityType), property));
+                Assert.assertTrue(jsonEqualsWithLinkResolving(new JSONObject(propertyChange), result.getMessages().values().iterator().next(), MqttHelper.getTopic(entityType, ids.get(entityType), property)));
+            }
+        });
+    }
+
+    /**
+     * This method will be run before starting the test for this conformance class. It initializes all objects and
+     * connections used within the test.
+     *
+     * @param testContext The test context to find out whether this class is requested to test or not
+     */
+    @BeforeClass
+    public void init(ITestContext testContext) {
+        Object obj = testContext.getSuite().getAttribute(
+                SuiteAttribute.LEVEL.getName());
+        if ((null != obj)) {
+            Integer level = Integer.class.cast(obj);
+            Assert.assertTrue(level > 7,
+                    "Conformance level 8 will not be checked since ics = " + level);
+        }
+
+        rootUri = testContext.getSuite().getAttribute(
+                SuiteAttribute.TEST_SUBJECT.getName()).toString();
+        rootUri = rootUri.trim();
+        if (rootUri.lastIndexOf('/') == rootUri.length() - 1) {
+            rootUri = rootUri.substring(0, rootUri.length() - 1);
+        }
+        if (testContext.getSuite().getAttribute(SuiteAttribute.MQTT_SERVER.getName()) == null) {
+            Assert.fail("Property '" + SuiteAttribute.MQTT_SERVER.getName() + "' not set in configuration");
+        }
+        String mqttServerUri = testContext.getSuite().getAttribute(SuiteAttribute.MQTT_SERVER.getName()).toString();
+        if (testContext.getSuite().getAttribute(SuiteAttribute.MQTT_TIMEOUT.getName()) == null) {
+            Assert.fail("Property '" + SuiteAttribute.MQTT_TIMEOUT.getName() + "' not set in configuration");
+        }
+        long mqttTimeout = Long.parseLong(testContext.getSuite().getAttribute(SuiteAttribute.MQTT_TIMEOUT.getName()).toString());
+
+        this.entityHelper = new EntityHelper(rootUri);
+        this.mqttHelper = new MqttHelper(mqttServerUri, mqttTimeout);
+    }
+
+    private String getPathToRelatedEntity(EntityType sourceEntityType, EntityType destinationEntityType) {
+        Queue<BFSStructure> queue = new LinkedList<>();
+        queue.offer(new BFSStructure(sourceEntityType, ""));
+        while (queue.peek() != null) {
+            BFSStructure currentElement = queue.poll();
+            List<String> relations = Arrays.asList(EntityRelations.getRelationsListFor(currentElement.entityType));
+            for (String relation : relations) {
+                EntityType relatedType = EntityRelations.getEntityTypeOfRelation(relation);
+                if (relatedType.equals(destinationEntityType)) {
+                    return currentElement.path
+                            + (currentElement.path.isEmpty()
+                                    ? relation
+                                    : "/" + relation);
+                } else {
+                    queue.offer(new BFSStructure(relatedType, currentElement.path + (currentElement.path.isEmpty() ? relation : "/" + relation)));
+                }
+            }
+        }
+        return "";
+    }
+
+    private void createEntities() {
+        ENTITY_TYPES_FOR_CREATE.stream().forEach((entityType) -> {
+            try {
+                ids.put(entityType, getInsertEntityAction(entityType).call());
+            } catch (Exception ex) {
+                Assert.fail("Could not create entities");
+            }
+        });
+    }
+
+    private void deleteCreatedEntities() {
+
+        ENTITY_TYPES_FOR_DELETE.stream().filter((entityType) -> (ids.containsKey(entityType))).map((entityType) -> {
+            entityHelper.deleteEntity(entityType, ids.get(entityType));
+            return entityType;
+        }).forEach((entityType) -> {
+            ids.remove(entityType);
+        });
+    }
+
+    private JSONObject filterEntity(JSONObject entity, List<String> selectedProperties) {
+        Iterator iterator = entity.keys();
+        while (iterator.hasNext()) {
+            String key = iterator.next().toString();
+            if (!selectedProperties.contains(key)) {
+                iterator.remove();
+            }
+        }
+        return entity;
+    }
+
+    private Callable<Long> getDeepInsertEntityAction(EntityType entityType) {
+        Callable<Long> trigger = () -> {
+            switch (entityType) {
+                case THING:
+                    return entityHelper.createThingWithDeepInsert();
+                case DATASTREAM:
+                    return entityHelper.createDatastreamWithDeepInsert(ids.get(EntityType.THING));
+                case OBSERVATION:
+                    return entityHelper.createObservationWithDeepInsert(ids.get(EntityType.DATASTREAM));
+            }
+            throw new IllegalArgumentException("Unknown EntityType '" + entityType.toString() + "'");
+        };
+        return trigger;
+    }
+
+    private Callable<Long> getInsertEntityAction(EntityType entityType) {
+        Callable<Long> trigger = () -> {
+            switch (entityType) {
+                case THING:
+                    return entityHelper.createThing();
+                case DATASTREAM:
+                    return entityHelper.createDatastream(ids.get(EntityType.THING), ids.get(EntityType.OBSERVED_PROPERTY), ids.get(EntityType.SENSOR));
+                case FEATURE_OF_INTEREST:
+                    return entityHelper.createFeatureOfInterest();
+                case HISTORICAL_LOCATION:
+                    return entityHelper.createHistoricalLocation(ids.get(EntityType.THING), ids.get(EntityType.LOCATION));
+                case LOCATION:
+                    return entityHelper.createLocation(ids.get(EntityType.THING));
+                case OBSERVATION:
+                    return entityHelper.createObservation(ids.get(EntityType.DATASTREAM), ids.get(EntityType.FEATURE_OF_INTEREST));
+                case OBSERVED_PROPERTY:
+                    return entityHelper.createObservedProperty();
+                case SENSOR:
+                    return entityHelper.createSensor();
+            }
+            throw new IllegalArgumentException("Unknown EntityType '" + entityType.toString() + "'");
+        };
+        return trigger;
+    }
+
+    private List<String> getSelectedProperties(EntityType entityType) {
+        String[] allProperties = EntityProperties.getPropertiesListFor(entityType);
+        List<String> selectedProperties = new ArrayList<>(allProperties.length / 2);
+        for (int i = 0; i < allProperties.length; i += 2) {
+            selectedProperties.add(allProperties[i]);
+        }
+        return selectedProperties;
+    }
+
+    private JSONObject getSubEntityByRoot(EntityType rootEntityType, Long rootId, EntityType subtEntityType) {
+        try {
+            String path = getPathToRelatedEntity(subtEntityType, rootEntityType);
+            path = "/" + EntityRelations.getRootEntitySet(subtEntityType) + "?$filter=" + path + "/id%20eq%20" + rootId;
+            JSONObject result = entityHelper.getEntity(path);
+            if (result.getInt("@iot.count") != 1) {
+                Assert.fail("Invalid result with size != 1");
+            }
+            JSONObject subEntity = result.getJSONArray("value").getJSONObject(0);
+            //helper.clearLinks(subEntity);
+            return subEntity;
+        } catch (JSONException ex) {
+            Assert.fail("Invalid JSON", ex);
+        }
+        throw new IllegalStateException();
+    }
+
+    private Callable<JSONObject> getUpdatePatchEntityAction(EntityType entityType) {
+        return () -> {
+            return entityHelper.updateEntitywithPATCH(entityType, ids.get(entityType));
+        };
+    }
+
+    private Callable<JSONObject> getUpdatePutEntityAction(EntityType entityType) {
+        return () -> {
+            return entityHelper.updateEntitywithPUT(entityType, ids.get(entityType));
+        };
+    }
+
+    private boolean jsonEqualsWithLinkResolving(JSONObject obj1, JSONObject obj2, String topic) {
+        if (obj1 == obj2) {
+            return true;
+        }
+        if (obj1 == null) {
+            return false;
+        }
+        if (obj1.getClass() != obj2.getClass()) {
+            return false;
+        }
+        if (obj1.length() != obj2.length()) {
+            return false;
+        }
+        Iterator iterator = obj1.keys();
+        while (iterator.hasNext()) {
+            String key = iterator.next().toString();
+            if (!obj2.has(key)) {
+                return false;
+            }
+            try {
+                Object val1 = obj1.get(key);
+                if (val1 instanceof JSONObject) {
+                    if (!jsonEqualsWithLinkResolving((JSONObject) val1, (JSONObject) obj2.getJSONObject(key), topic)) {
+                        return false;
+                    }
+                } else if (val1 instanceof JSONArray) {
+                    JSONArray arr1 = (JSONArray) val1;
+                    if (!jsonEqualsWithLinkResolving(arr1.toJSONObject(arr1), obj2.getJSONArray(key).toJSONObject(obj2.getJSONArray(key)), topic)) {
+                        return false;
+                    }
+                } else if (topic != null && !topic.isEmpty() && key.endsWith("@iot.navigationLink")) {
+                    String version = topic.substring(0, topic.indexOf("/"));
+
+                    String selfLink1 = obj1.getString("@iot.selfLink");
+                    URI baseUri1 = URI.create(selfLink1.substring(0, selfLink1.indexOf(version))).resolve(topic);
+                    String absoluteUri1 = baseUri1.resolve(obj1.getString(key)).toString();
+
+                    String selfLink2 = obj2.getString("@iot.selfLink");
+                    URI baseUri2 = URI.create(selfLink2.substring(0, selfLink2.indexOf(version))).resolve(topic);
+                    String absoluteUri2 = baseUri2.resolve(obj2.getString(key)).toString();
+                    return absoluteUri1.equals(absoluteUri2);
+
+                } else if (!val1.equals(obj2.get(key))) {
+                    return false;
+                }
+            } catch (JSONException ex) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private class BFSStructure {
+
+        EntityType entityType;
+        String path;
+
+        public BFSStructure(EntityType entityType, String path) {
+            this.entityType = entityType;
+            this.path = path;
+        }
+    }
+}

--- a/src/main/java/org/opengis/cite/sta10/receiveUpdatesViaMQTT/Capability8Test.java
+++ b/src/main/java/org/opengis/cite/sta10/receiveUpdatesViaMQTT/Capability8Test.java
@@ -73,8 +73,9 @@ public class Capability8Test {
     private MqttHelper mqttHelper;
     private String rootUri;
 
-    @Test(description = "Subcribe to EntitySet and insert Entity", groups = "level-8", priority = 1)
+    @Test(description = "Subcribe to EntitySet and insert Entity", groups = "level-8")
     public void checkSubscribeToEntitySetInsert() {
+        deleteCreatedEntities();
         ENTITY_TYPES_FOR_CREATE.stream().forEach((entityType) -> {
             MqttBatchResult<Long> result = mqttHelper.executeRequests(getInsertEntityAction(entityType), MqttHelper.getTopic(entityType));
             ids.put(entityType, result.getActionResult());
@@ -82,7 +83,7 @@ public class Capability8Test {
         });
     }
 
-    @Test(description = "Subcribe to EntitySet and update (PATCH) Entity", groups = "level-8", priority = 3)
+    @Test(description = "Subcribe to EntitySet and update (PATCH) Entity", groups = "level-8")
     public void checkSubscribeToEntitySetUpdatePATCH() {
         deleteCreatedEntities();
         createEntities();
@@ -92,15 +93,17 @@ public class Capability8Test {
         });
     }
 
-    @Test(description = "Subcribe to EntitySet and update (PUT) Entity", groups = "level-8", priority = 2)
+    @Test(description = "Subcribe to EntitySet and update (PUT) Entity", groups = "level-8")
     public void checkSubscribeToEntitySetUpdatePUT() {
+        deleteCreatedEntities();
+        createEntities();
         ENTITY_TYPES_FOR_CREATE.stream().forEach((entityType) -> {
             MqttBatchResult<JSONObject> result = mqttHelper.executeRequests(getUpdatePutEntityAction(entityType), MqttHelper.getTopic(entityType));
             Assert.assertTrue(jsonEqualsWithLinkResolving(result.getActionResult(), result.getMessages().values().iterator().next(), MqttHelper.getTopic(entityType)));
         });
     }
 
-    @Test(description = "Subcribe to EntitySet with multiple $select and insert Entity", groups = "level-8", priority = 8)
+    @Test(description = "Subcribe to EntitySet with multiple $select and insert Entity", groups = "level-8")
     public void checkSubscribeToEntitySetWithMultipleSelectInsert() {
         deleteCreatedEntities();
         ENTITY_TYPES_FOR_CREATE.stream().forEach((entityType) -> {
@@ -113,7 +116,7 @@ public class Capability8Test {
         });
     }
 
-    @Test(description = "Subcribe to EntitySet with multiple $select and update (PATCH) Entity", groups = "level-8", priority = 10)
+    @Test(description = "Subcribe to EntitySet with multiple $select and update (PATCH) Entity", groups = "level-8")
     public void checkSubscribeToEntitySetWithMultipleSelectUpdatePATCH() {
         deleteCreatedEntities();
         createEntities();
@@ -130,8 +133,10 @@ public class Capability8Test {
         });
     }
 
-    @Test(description = "Subcribe to EntitySet with multiple $select and update (PUT) Entity", groups = "level-8", priority = 9)
+    @Test(description = "Subcribe to EntitySet with multiple $select and update (PUT) Entity", groups = "level-8")
     public void checkSubscribeToEntitySetWithMultipleSelectUpdatePUT() {
+        deleteCreatedEntities();
+        createEntities();
         ENTITY_TYPES_FOR_CREATE.stream().forEach((entityType) -> {
             List<String> selectedProperties = getSelectedProperties(entityType);
 
@@ -145,7 +150,7 @@ public class Capability8Test {
         });
     }
 
-    @Test(description = "Subcribe to EntitySet via relative topic", groups = "level-8", priority = 8)
+    @Test(description = "Subcribe to EntitySet via relative topic", groups = "level-8")
     public void checkSubscribeToEntitySetWithRelativeTopicUpdatePUT() {
         deleteCreatedEntities();
         createEntities();
@@ -168,7 +173,7 @@ public class Capability8Test {
         });
     }
 
-    @Test(description = "Subcribe to multiple EntitySets and deep insert multiple entites", groups = "level-8", priority = 8)
+    @Test(description = "Subcribe to multiple EntitySets and deep insert multiple entites", groups = "level-8")
     public void checkSubscribeToEntitySetsWithDeepInsert() {
         deleteCreatedEntities();
         ENTITY_TYPES_FOR_DEEP_INSERT.stream().forEach((EntityType entityType) -> {
@@ -199,7 +204,7 @@ public class Capability8Test {
         });
     }
 
-    @Test(description = "Subcribe to Entity and update (PATCH) Entity", groups = "level-8", priority = 5)
+    @Test(description = "Subcribe to Entity and update (PATCH) Entity", groups = "level-8")
     public void checkSubscribeToEntityUpdatePATCH() {
         deleteCreatedEntities();
         createEntities();
@@ -209,7 +214,7 @@ public class Capability8Test {
         });
     }
 
-    @Test(description = "Subcribe to Entity and update (PUT) Entity", groups = "level-8", priority = 4)
+    @Test(description = "Subcribe to Entity and update (PUT) Entity", groups = "level-8")
     public void checkSubscribeToEntityUpdatePUT() {
         deleteCreatedEntities();
         createEntities();
@@ -219,7 +224,7 @@ public class Capability8Test {
         });
     }
 
-    @Test(description = "Subcribe to Entity via relative topic", groups = "level-8", priority = 8)
+    @Test(description = "Subcribe to Entity via relative topic", groups = "level-8")
     public void checkSubscribeToEntityWithRelativeTopicUpdatePUT() {
         deleteCreatedEntities();
         createEntities();
@@ -237,7 +242,7 @@ public class Capability8Test {
         });
     }
 
-    @Test(description = "Subcribe to Property and update (PATCH) Entity", groups = "level-8", priority = 7)
+    @Test(description = "Subcribe to Property and update (PATCH) Entity", groups = "level-8")
     public void checkSubscribeToPropertyUpdatePATCH() {
         deleteCreatedEntities();
         createEntities();
@@ -256,7 +261,7 @@ public class Capability8Test {
         });
     }
 
-    @Test(description = "Subcribe to Property and update (PUT) Entity", groups = "level-8", priority = 6)
+    @Test(description = "Subcribe to Property and update (PUT) Entity", groups = "level-8")
     public void checkSubscribeToPropertyUpdatePUT() {
         deleteCreatedEntities();
         createEntities();

--- a/src/main/java/org/opengis/cite/sta10/receiveUpdatesViaMQTT/DeepInsertInfo.java
+++ b/src/main/java/org/opengis/cite/sta10/receiveUpdatesViaMQTT/DeepInsertInfo.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2016 Open Geospatial Consortium.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opengis.cite.sta10.receiveUpdatesViaMQTT;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.opengis.cite.sta10.util.EntityType;
+
+/**
+ *
+ * @author jab
+ */
+public class DeepInsertInfo {
+
+    private final EntityType entityType;
+    private final List<EntityType> subEntityTypes;
+
+    public DeepInsertInfo(EntityType entityType, List<EntityType> subEntityTypes) {
+        this.entityType = entityType;
+        this.subEntityTypes = subEntityTypes;
+    }
+
+    public DeepInsertInfo(EntityType entityType) {
+        this.entityType = entityType;
+        this.subEntityTypes = new ArrayList<>();
+    }
+
+    public EntityType getEntityType() {
+        return entityType;
+    }
+
+    public List<EntityType> getSubEntityTypes() {
+        return subEntityTypes;
+    }
+
+}

--- a/src/main/java/org/opengis/cite/sta10/receiveUpdatesViaMQTT/EntityHelper.java
+++ b/src/main/java/org/opengis/cite/sta10/receiveUpdatesViaMQTT/EntityHelper.java
@@ -53,6 +53,42 @@ public class EntityHelper {
         return s1 + s2.substring(idx + 1);
     }
 
+    public void deleteEverything() {
+        deleteEntityType(EntityType.OBSERVATION);
+        deleteEntityType(EntityType.FEATURE_OF_INTEREST);
+        deleteEntityType(EntityType.DATASTREAM);
+        deleteEntityType(EntityType.SENSOR);
+        deleteEntityType(EntityType.OBSERVED_PROPERTY);
+        deleteEntityType(EntityType.HISTORICAL_LOCATION);
+        deleteEntityType(EntityType.LOCATION);
+        deleteEntityType(EntityType.THING);
+    }
+
+    /**
+     * Delete all the entities of a certain entity type
+     *
+     * @param entityType The entity type from EntityType enum
+     */
+    private void deleteEntityType(EntityType entityType) {
+        JSONArray array = null;
+        do {
+            try {
+                String urlString = ServiceURLBuilder.buildURLString(rootUri, entityType, -1, null, null);
+                Map<String, Object> responseMap = HTTPMethods.doGet(urlString);
+                int responseCode = Integer.parseInt(responseMap.get("response-code").toString());
+                JSONObject result = new JSONObject(responseMap.get("response").toString());
+                array = result.getJSONArray("value");
+                for (int i = 0; i < array.length(); i++) {
+                    long id = array.getJSONObject(i).getLong(ControlInformation.ID);
+                    deleteEntity(entityType, id);
+                }
+            } catch (JSONException e) {
+                e.printStackTrace();
+                Assert.fail("An Exception occurred during testing!:\n" + e.getMessage());
+            }
+        } while (array.length() > 0);
+    }
+
     public long createDatastream(long thingId, long observedPropertyId, long sensorId) {
         try {
             String urlParameters = "{\n"

--- a/src/main/java/org/opengis/cite/sta10/receiveUpdatesViaMQTT/EntityHelper.java
+++ b/src/main/java/org/opengis/cite/sta10/receiveUpdatesViaMQTT/EntityHelper.java
@@ -1,0 +1,583 @@
+/*
+ * Copyright 2016 Open Geospatial Consortium.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opengis.cite.sta10.receiveUpdatesViaMQTT;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.opengis.cite.sta10.util.ControlInformation;
+import org.opengis.cite.sta10.util.EntityType;
+import org.opengis.cite.sta10.util.HTTPMethods;
+import org.opengis.cite.sta10.util.ServiceURLBuilder;
+import org.testng.Assert;
+
+/**
+ *
+ * @author jab
+ */
+public class EntityHelper {
+
+    private final String rootUri;
+
+    public EntityHelper(String rootUri) {
+        this.rootUri = rootUri;
+    }
+
+    private static String concatOverlapping(String s1, String s2) {
+        if (!s1.contains(s2.substring(0, 1))) {
+            return s1 + s2;
+        }
+        int idx = s2.length();
+        try {
+            while (!s1.endsWith(s2.substring(0, idx--))) ;
+        } catch (Exception e) {
+        }
+        return s1 + s2.substring(idx + 1);
+    }
+
+    public long createDatastream(long thingId, long observedPropertyId, long sensorId) {
+        try {
+            String urlParameters = "{\n"
+                    + "  \"unitOfMeasurement\": {\n"
+                    + "    \"name\": \"Celsius\",\n"
+                    + "    \"symbol\": \"degC\",\n"
+                    + "    \"definition\": \"http://qudt.org/vocab/unit#DegreeCelsius\"\n"
+                    + "  },\n"
+                    + "  \"name\": \"test datastream.\",\n"
+                    + "  \"description\": \"test datastream.\",\n"
+                    + "  \"phenomenonTime\": \"2014-03-01T13:00:00Z/2015-05-11T15:30:00Z\",\n"
+                    + "  \"resultTime\": \"2014-03-01T13:00:00Z/2015-05-11T15:30:00Z\",\n"
+                    + "  \"observationType\": \"http://www.opengis.net/def/observationType/OGC-OM/2.0/OM_Measurement\",\n"
+                    + "  \"Thing\": { \"@iot.id\": " + thingId + " },\n"
+                    + "  \"ObservedProperty\":{ \"@iot.id\":" + observedPropertyId + "},\n"
+                    + "  \"Sensor\": { \"@iot.id\": " + sensorId + " }\n"
+                    + "}";
+            JSONObject entity = postEntity(EntityType.DATASTREAM, urlParameters);
+            return entity.getLong(ControlInformation.ID);
+        } catch (JSONException e) {
+            Assert.fail("An Exception occurred during testing!:\n" + e.getMessage());
+        }
+        return -1;
+    }
+
+    public Long createDatastreamWithDeepInsert(long thingId) {
+        try {
+            String urlParameters = "{\n"
+                    + "  \"unitOfMeasurement\": {\n"
+                    + "    \"name\": \"Celsius\",\n"
+                    + "    \"symbol\": \"degC\",\n"
+                    + "    \"definition\": \"http://qudt.org/vocab/unit#DegreeCelsius\"\n"
+                    + "  },\n"
+                    + "  \"name\": \"test datastream.\",\n"
+                    + "  \"description\": \"test datastream.\",\n"
+                    + "  \"observationType\": \"http://www.opengis.net/def/observationType/OGC-OM/2.0/OM_Measurement\",\n"
+                    + "  \"Thing\": { \"@iot.id\": " + thingId + " },\n"
+                    + "   \"ObservedProperty\": {\n"
+                    + "        \"name\": \"Luminous Flux\",\n"
+                    + "        \"definition\": \"http://www.qudt.org/qudt/owl/1.0.0/quantity/Instances.html#LuminousFlux\",\n"
+                    + "        \"description\": \"Luminous Flux or Luminous Power is the measure of the perceived power of light.\"\n"
+                    + "   },\n"
+                    + "   \"Sensor\": {        \n"
+                    + "        \"name\": \"Acme Fluxomatic 1000\",\n"
+                    + "        \"description\": \"Acme Fluxomatic 1000\",\n"
+                    + "        \"encodingType\": \"http://schema.org/description\",\n"
+                    + "        \"metadata\": \"Light flux sensor\"\n"
+                    + "   },\n"
+                    + "      \"Observations\": [\n"
+                    + "        {\n"
+                    + "          \"phenomenonTime\": \"2015-03-01T00:10:00Z\",\n"
+                    + "          \"result\": 10\n"
+                    + "        }\n"
+                    + "      ]"
+                    + "}";
+            JSONObject entity = postEntity(EntityType.DATASTREAM, urlParameters);
+            return entity.getLong(ControlInformation.ID);
+        } catch (JSONException ex) {
+            Assert.fail("An Exception occurred during testing!", ex);
+        }
+        return -1l;
+    }
+
+    public long createFeatureOfInterest() {
+        try {
+            String urlParameters = "{\n"
+                    + "  \"name\": \"A weather station.\",\n"
+                    + "  \"description\": \"A weather station.\",\n"
+                    + "  \"encodingType\": \"application/vnd.geo+json\",\n"
+                    + "  \"feature\": {\n"
+                    + "    \"type\": \"Point\",\n"
+                    + "    \"coordinates\": [\n"
+                    + "      10,\n"
+                    + "      10\n"
+                    + "    ]\n"
+                    + "  }\n"
+                    + "}";
+            JSONObject entity = postEntity(EntityType.FEATURE_OF_INTEREST, urlParameters);
+            return entity.getLong(ControlInformation.ID);
+        } catch (JSONException e) {
+            Assert.fail("An Exception occurred during testing!:\n" + e.getMessage());
+        }
+        return -1;
+    }
+
+    public long createHistoricalLocation(long thingId, long locationId) {
+        try {
+            String urlParameters = "{\n"
+                    + "  \"time\": \"2015-03-01T00:40:00.000Z\",\n"
+                    + "  \"Thing\":{\"@iot.id\": " + thingId + "},\n"
+                    + "  \"Locations\": [{\"@iot.id\": " + locationId + "}]  \n"
+                    + "}";
+            JSONObject entity = postEntity(EntityType.HISTORICAL_LOCATION, urlParameters);
+            return entity.getLong(ControlInformation.ID);
+        } catch (JSONException e) {
+            Assert.fail("An Exception occurred during testing!:\n" + e.getMessage());
+        }
+        return -1;
+    }
+
+    public long createLocation(long thingId) {
+        try {
+            String urlParameters = "{\n"
+                    + "  \"name\": \"bow river\",\n"
+                    + "  \"description\": \"bow river\",\n"
+                    + "  \"encodingType\": \"application/vnd.geo+json\",\n"
+                    + "  \"Things\":[{\"@iot.id\": " + thingId + "}],\n"
+                    + "  \"location\": { \"type\": \"Point\", \"coordinates\": [-114.05, 51.05] }\n"
+                    + "}";
+            JSONObject entity = postEntity(EntityType.LOCATION, urlParameters);
+            return entity.getLong(ControlInformation.ID);
+        } catch (JSONException e) {
+            Assert.fail("An Exception occurred during testing!:\n" + e.getMessage());
+        }
+        return -1;
+    }
+
+    public long createObservation(long datastreamId, long featureOfInterstId) {
+        try {
+            String urlParameters = "{\n"
+                    + "  \"phenomenonTime\": \"2015-03-01T00:40:00.000Z\",\n"
+                    + "  \"validTime\": \"2016-01-01T02:01:01+01:00/2016-01-02T00:59:59+01:00\",\n"
+                    + "  \"result\": 8,\n"
+                    + "  \"parameters\":{\"param1\": \"some value1\", \"param2\": \"some value2\"},\n"
+                    + "  \"Datastream\":{\"@iot.id\": " + datastreamId + "},\n"
+                    + "  \"FeatureOfInterest\": {\"@iot.id\": " + featureOfInterstId + "}  \n"
+                    + "}";
+            JSONObject entity = postEntity(EntityType.OBSERVATION, urlParameters);
+            return entity.getLong(ControlInformation.ID);
+        } catch (JSONException e) {
+            Assert.fail("An Exception occurred during testing!:\n" + e.getMessage());
+        }
+        return -1;
+    }
+
+    public Long createObservationWithDeepInsert(long datastreamId) {
+        try {
+            String urlParameters = "{\n"
+                    + "  \"phenomenonTime\": \"2015-03-01T00:00:00Z\",\n"
+                    + "  \"result\": 100,\n"
+                    + "  \"FeatureOfInterest\": {\n"
+                    + "  \t\"name\": \"A weather station.\",\n"
+                    + "  \t\"description\": \"A weather station.\",\n"
+                    + "  \t\"encodingType\": \"application/vnd.geo+json\",\n"
+                    + "    \"feature\": {\n"
+                    + "      \"type\": \"Point\",\n"
+                    + "      \"coordinates\": [\n"
+                    + "        -114.05,\n"
+                    + "        51.05\n"
+                    + "      ]\n"
+                    + "    }\n"
+                    + "  },\n"
+                    + "  \"Datastream\":{\"@iot.id\": " + datastreamId + "}\n"
+                    + "}";
+            JSONObject entity = postEntity(EntityType.OBSERVATION, urlParameters);
+            return entity.getLong(ControlInformation.ID);
+        } catch (JSONException ex) {
+            Assert.fail("An Exception occurred during testing!", ex);
+        }
+        return -1l;
+    }
+
+    public long createObservedProperty() {
+        try {
+            String urlParameters = "{\n"
+                    + "  \"name\": \"DewPoint Temperature\",\n"
+                    + "  \"definition\": \"http://dbpedia.org/page/Dew_point\",\n"
+                    + "  \"description\": \"The dewpoint temperature is the temperature to which the air must be cooled, at constant pressure, for dew to form. As the grass and other objects near the ground cool to the dewpoint, some of the water vapor in the atmosphere condenses into liquid water on the objects.\"\n"
+                    + "}";
+            JSONObject entity = postEntity(EntityType.OBSERVED_PROPERTY, urlParameters);
+            return entity.getLong(ControlInformation.ID);
+        } catch (JSONException e) {
+            Assert.fail("An Exception occurred during testing!:\n" + e.getMessage());
+        }
+        return -1;
+    }
+
+    public long createSensor() {
+        try {
+            String urlParameters = "{\n"
+                    + "  \"name\": \"Fuguro Barometer\",\n"
+                    + "  \"description\": \"Fuguro Barometer\",\n"
+                    + "  \"encodingType\": \"http://schema.org/description\",\n"
+                    + "  \"metadata\": \"Barometer\"\n"
+                    + "}";
+            JSONObject entity = postEntity(EntityType.SENSOR, urlParameters);
+            return entity.getLong(ControlInformation.ID);
+        } catch (JSONException e) {
+            Assert.fail("An Exception occurred during testing!:\n" + e.getMessage());
+        }
+        return -1;
+    }
+
+    public long createThing() {
+        try {
+            String urlParameters = "{"
+                    + "\"name\":\"Test Thing\","
+                    + "\"description\":\"This is a Test Thing From TestNG\""
+                    + "}";
+            JSONObject entity = postEntity(EntityType.THING, urlParameters);
+            return entity.getLong(ControlInformation.ID);
+        } catch (JSONException e) {
+            Assert.fail("An Exception occurred during testing!:\n" + e.getMessage());
+        }
+        return -1;
+    }
+
+    public Long createThingWithDeepInsert() {
+        try {
+            String urlParameters = "{\n"
+                    + "  \"name\": \"Office Building\",\n"
+                    + "  \"description\": \"Office Building\",\n"
+                    + "  \"properties\": {\n"
+                    + "    \"reference\": \"Third Floor\"\n"
+                    + "  },\n"
+                    + "  \"Locations\": [\n"
+                    + "    {\n"
+                    + "      \"name\": \"West Roof\",\n"
+                    + "      \"description\": \"West Roof\",\n"
+                    + "      \"location\": { \"type\": \"Point\", \"coordinates\": [-117.05, 51.05] },\n"
+                    + "      \"encodingType\": \"application/vnd.geo+json\"\n"
+                    + "    }\n"
+                    + "  ],\n"
+                    + "  \"Datastreams\": [\n"
+                    + "    {\n"
+                    + "      \"unitOfMeasurement\": {\n"
+                    + "        \"name\": \"Lumen\",\n"
+                    + "        \"symbol\": \"lm\",\n"
+                    + "        \"definition\": \"http://www.qudt.org/qudt/owl/1.0.0/unit/Instances.html#Lumen\"\n"
+                    + "      },\n"
+                    + "      \"name\": \"Light exposure.\",\n"
+                    + "      \"description\": \"Light exposure.\",\n"
+                    + "      \"observationType\": \"http://www.opengis.net/def/observationType/OGC-OM/2.0/OM_Measurement\",\n"
+                    + "      \"ObservedProperty\": {\n"
+                    + "        \"name\": \"Luminous Flux\",\n"
+                    + "        \"definition\": \"http://www.qudt.org/qudt/owl/1.0.0/quantity/Instances.html#LuminousFlux\",\n"
+                    + "        \"description\": \"Luminous Flux or Luminous Power is the measure of the perceived power of light.\"\n"
+                    + "      },\n"
+                    + "      \"Sensor\": {        \n"
+                    + "        \"name\": \"Acme Fluxomatic 1000\",\n"
+                    + "        \"description\": \"Acme Fluxomatic 1000\",\n"
+                    + "        \"encodingType\": \"http://schema.org/description\",\n"
+                    + "        \"metadata\": \"Light flux sensor\"\n"
+                    + "      }\n"
+                    + "    }\n"
+                    + "  ]\n"
+                    + "}";
+            JSONObject entity = postEntity(EntityType.THING, urlParameters);
+            return entity.getLong(ControlInformation.ID);
+        } catch (JSONException ex) {
+            Assert.fail("An Exception occurred during testing!", ex);
+        }
+        return -1l;
+    }
+
+    public void deleteEntity(EntityType entityType, long id) {
+        String urlString = ServiceURLBuilder.buildURLString(rootUri, entityType, id, null, null);
+        Map<String, Object> responseMap = HTTPMethods.doDelete(urlString);
+        int responseCode = Integer.parseInt(responseMap.get("response-code").toString());
+        Assert.assertEquals(responseCode, 200, "DELETE does not work properly for " + entityType + " with id " + id + ". Returned with response code " + responseCode + ".");
+
+        responseMap = HTTPMethods.doGet(urlString);
+        responseCode = Integer.parseInt(responseMap.get("response-code").toString());
+        Assert.assertEquals(responseCode, 404, "Deleted entity was not actually deleted : " + entityType + "(" + id + ").");
+    }
+
+    public DeepInsertInfo getDeepInsertInfo(EntityType entityType) {
+        DeepInsertInfo result = new DeepInsertInfo(entityType);
+        switch (entityType) {
+            case THING: {
+                result.getSubEntityTypes().add(EntityType.LOCATION);
+                result.getSubEntityTypes().add(EntityType.DATASTREAM);
+                result.getSubEntityTypes().add(EntityType.OBSERVED_PROPERTY);
+                result.getSubEntityTypes().add(EntityType.SENSOR);
+                break;
+            }
+            case DATASTREAM: {
+                result.getSubEntityTypes().add(EntityType.OBSERVATION);
+                result.getSubEntityTypes().add(EntityType.OBSERVED_PROPERTY);
+                result.getSubEntityTypes().add(EntityType.SENSOR);
+                break;
+            }
+            case OBSERVATION: {
+                result.getSubEntityTypes().add(EntityType.FEATURE_OF_INTEREST);
+                break;
+            }
+            default:
+                throw new IllegalStateException();
+        }
+        return result;
+    }
+
+    public JSONObject getEntity(EntityType entityType, long id) {
+        if (id == -1) {
+            return null;
+        }
+        String urlString = ServiceURLBuilder.buildURLString(rootUri, entityType, id, null, null);
+        try {
+            return new JSONObject(HTTPMethods.doGet(urlString).get("response").toString());
+        } catch (JSONException e) {
+            Assert.fail("An Exception occurred during testing!:\n" + e.getMessage());
+            return null;
+        }
+    }
+
+    public JSONObject getEntity(String relativeUrl) {
+        String urlString = concatOverlapping(rootUri, relativeUrl);
+        try {
+            return new JSONObject(HTTPMethods.doGet(urlString).get("response").toString());
+        } catch (JSONException e) {
+            Assert.fail("An Exception occurred during testing!:\n" + e.getMessage());
+            return null;
+        }
+    }
+
+    public Map<String, Object> getEntityChanges(EntityType entityType, List<String> selectedProperties) {
+        return getEntityChanges(entityType).entrySet().stream().filter(x -> selectedProperties.contains(x.getKey())).collect(Collectors.toMap(x -> x.getKey(), x -> x.getValue()));
+    }
+
+    public Map<String, Object> getEntityChanges(EntityType entityType) {
+        switch (entityType) {
+            case THING:
+                return getThingChanges();
+            case DATASTREAM:
+                return getDatastreamChanges();
+            case FEATURE_OF_INTEREST:
+                return getFeatureOfInterestChanges();
+            case HISTORICAL_LOCATION:
+                return getHistoricalLocationChanges();
+            case LOCATION:
+                return getLocationChanges();
+            case OBSERVATION:
+                return getObservationChanges();
+            case OBSERVED_PROPERTY:
+                return getObservedPropertyChanges();
+            case SENSOR:
+                return getSensorChanges();
+            default:
+                throw new IllegalStateException("Unsupported entityType '" + entityType + "'");
+        }
+    }
+
+    public JSONObject patchEntity(EntityType entityType, Map<String, Object> changes, long id) {
+        String urlString = ServiceURLBuilder.buildURLString(rootUri, entityType, id, null, null);
+        try {
+            Map<String, Object> responseMap = HTTPMethods.doPatch(urlString, new JSONObject(changes).toString());
+            int responseCode = Integer.parseInt(responseMap.get("response-code").toString());
+            Assert.assertEquals(responseCode, 200, "Error during updating(PATCH) of entity " + entityType.name());
+
+            responseMap = HTTPMethods.doGet(urlString);
+            JSONObject result = new JSONObject(responseMap.get("response").toString());
+            return result;
+
+        } catch (JSONException e) {
+            Assert.fail("An Exception occurred during testing!:\n" + e.getMessage());
+            return null;
+        }
+    }
+
+    public JSONObject putEntity(EntityType entityType, Map<String, Object> changes, long id) {
+        String urlString = ServiceURLBuilder.buildURLString(rootUri, entityType, id, null, null);
+        try {
+            JSONObject entity = getEntity(entityType, id);
+            clearLinks(entity);
+            for (Map.Entry<String, Object> entry : changes.entrySet()) {
+                entity.put(entry.getKey(), entry.getValue());
+            }
+            Map<String, Object> responseMap = HTTPMethods.doPut(urlString, entity.toString());
+            int responseCode = Integer.parseInt(responseMap.get("response-code").toString());
+            Assert.assertEquals(responseCode, 200, "Error during updating(PUT) of entity " + entityType.name());
+            responseMap = HTTPMethods.doGet(urlString);
+            JSONObject result = new JSONObject(responseMap.get("response").toString());
+            return result;
+
+        } catch (JSONException e) {
+            Assert.fail("An Exception occurred during testing!:\n" + e.getMessage());
+            return null;
+        }
+    }
+
+    public JSONObject updateEntitywithPATCH(EntityType entityType, long id) {
+        return patchEntity(entityType, getEntityChanges(entityType), id);
+    }
+
+    public JSONObject updateEntitywithPUT(EntityType entityType, long id) {
+        return putEntity(entityType, getEntityChanges(entityType), id);
+    }
+
+    private void clearLinks(Object obj) {
+        if (!(obj instanceof JSONObject)) {
+            return;
+        }
+        JSONObject entity = (JSONObject) obj;
+        Iterator iterator = entity.keys();
+        while (iterator.hasNext()) {
+            String key = iterator.next().toString();
+            if (key.contains("@")) {
+                iterator.remove();
+                //entity.remove(key);
+            } else {
+                try {
+                    Object val = entity.get(key);
+                    if (val instanceof JSONObject) {
+                        clearLinks((JSONObject) val);
+                    } else if (val instanceof JSONArray) {
+                        JSONArray arr = (JSONArray) val;
+                        for (int i = 0; i < arr.length(); i++) {
+                            clearLinks(arr.get(i));
+                        }
+                    }
+                } catch (JSONException ex) {
+                    Assert.fail();
+                }
+            }
+        }
+    }
+
+    private Map<String, Object> getDatastreamChanges() {
+        try {
+            Map<String, Object> changes = new HashMap<>();
+            changes.put("name", "Data coming from sensor on ISS.");
+            changes.put("description", "Data coming from sensor on ISS.");
+            changes.put("observationType", "http://www.opengis.net/def/observationType/OGC-OM/2.0/OM_Observation");
+            changes.put("unitOfMeasurement", new JSONObject("{\"name\": \"Entropy\",\"symbol\": \"S\",\"definition\": \"http://qudt.org/vocab/unit#Entropy\"}"));
+            changes.put("phenomenonTime", "2015-12-12T12:12:12Z/2015-12-12T15:30:00Z");
+            changes.put("resultTime", "2015-12-12T12:12:12Z/2015-12-12T15:30:00Z");
+            return changes;
+        } catch (JSONException ex) {
+            Assert.fail("Generating Datastream changes failed", ex);
+        }
+        throw new IllegalStateException();
+    }
+
+    private Map<String, Object> getFeatureOfInterestChanges() {
+        try {
+            Map<String, Object> changes = new HashMap<>();
+            changes.put("encodingType", "SQUARE");
+            changes.put("feature", new JSONObject("{ \"type\": \"Point\", \"coordinates\": [-114.05, 51.05] }"));
+            changes.put("name", "POIUYTREW");
+            changes.put("description", "POIUYTREW");
+            return changes;
+        } catch (JSONException ex) {
+            Assert.fail("Generating FeatureOfInterest changes failed", ex);
+        }
+        throw new IllegalStateException();
+    }
+
+    private Map<String, Object> getHistoricalLocationChanges() {
+        Map<String, Object> changes = new HashMap<>();
+        changes.put("time", "2015-08-01T00:00:00.000Z");
+        return changes;
+    }
+
+    private Map<String, Object> getLocationChanges() {
+        try {
+            Map<String, Object> changes = new HashMap<>();
+            changes.put("encodingType", "UPDATED ENCODING");
+            changes.put("name", "UPDATED NAME");
+            changes.put("description", "UPDATED DESCRIPTION");
+            changes.put("location", new JSONObject("{ \"type\": \"Point\", \"coordinates\": [-114.05, 50] }}"));
+            return changes;
+        } catch (JSONException ex) {
+            Assert.fail("Generating Location changes failed", ex);
+        }
+        throw new IllegalStateException();
+    }
+
+    private Map<String, Object> getObservationChanges() {
+        try {
+            Map<String, Object> changes = new HashMap<>();
+            changes.put("result", "99");
+            changes.put("phenomenonTime", "2015-08-01T00:40:00.000Z");
+            changes.put("resultTime", "2015-12-12T12:12:12.000Z");
+            changes.put("validTime", "2016-12-12T12:12:12+01:00/2016-12-12T23:59:59+01:00");
+            changes.put("parameters", new JSONObject("{\"param1\": \"some updated value1\", \"param2\": \"some updated value2\"}"));
+
+            return changes;
+        } catch (JSONException ex) {
+            Assert.fail("Generating Observation changes failed", ex);
+        }
+        throw new IllegalStateException();
+    }
+
+    private Map<String, Object> getObservedPropertyChanges() {
+        Map<String, Object> changes = new HashMap<>();
+        changes.put("name", "QWERTY");
+        changes.put("definition", "ZXCVB");
+        changes.put("description", "POIUYTREW");
+        return changes;
+    }
+
+    private Map<String, Object> getSensorChanges() {
+        Map<String, Object> changes = new HashMap<>();
+        changes.put("name", "UPDATED");
+        changes.put("description", "UPDATED");
+        changes.put("encodingType", "http://schema.org/newDescription");
+        changes.put("metadata", "UPDATED");
+        return changes;
+    }
+
+    private Map<String, Object> getThingChanges() {
+        Map<String, Object> changes = new HashMap<>();
+        changes.put("name", "This is a Updated Test Thing From TestNG");
+        changes.put("description", "This is a Updated Test Thing From TestNG");
+        return changes;
+    }
+
+    private JSONObject postEntity(EntityType entityType, String urlParameters) {
+        String urlString = ServiceURLBuilder.buildURLString(rootUri, entityType, -1, null, null);
+        try {
+            Map<String, Object> responseMap = HTTPMethods.doPost(urlString, urlParameters);
+            int responseCode = Integer.parseInt(responseMap.get("response-code").toString());
+            Assert.assertEquals(responseCode, 201, "Error during creation of entity " + entityType.name());
+            String response = responseMap.get("response").toString();
+            long id = Long.parseLong(response.substring(response.indexOf("(") + 1, response.indexOf(")")));
+            urlString = urlString + "(" + id + ")";
+            responseMap = HTTPMethods.doGet(urlString);
+            responseCode = Integer.parseInt(responseMap.get("response-code").toString());
+            Assert.assertEquals(responseCode, 200, "The POSTed entity is not created.");
+            JSONObject result = new JSONObject(responseMap.get("response").toString());
+            return result;
+        } catch (JSONException e) {
+            Assert.fail("An Exception occurred during testing!:\n" + e.getMessage());
+            return null;
+        }
+    }
+
+}

--- a/src/main/java/org/opengis/cite/sta10/receiveUpdatesViaMQTT/MqttBatchResult.java
+++ b/src/main/java/org/opengis/cite/sta10/receiveUpdatesViaMQTT/MqttBatchResult.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2016 Open Geospatial Consortium.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opengis.cite.sta10.receiveUpdatesViaMQTT;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.json.JSONObject;
+
+/**
+ *
+ * @author jab
+ */
+public class MqttBatchResult<T> {
+
+    private T actionResult;
+    private Map<String, JSONObject> messages;
+
+    public MqttBatchResult() {
+        messages = new HashMap<>();
+    }
+
+    public MqttBatchResult(int size) {
+        messages = new HashMap<>(size);
+    }
+
+    public MqttBatchResult withActionResult(T actionResult) {
+        setActionResult(actionResult);
+        return this;
+    }
+
+    public MqttBatchResult withMessages(Map<String, JSONObject> messages) {
+        setMessages(messages);
+        return this;
+    }
+
+    public T getActionResult() {
+        return actionResult;
+    }
+
+    public Map<String, JSONObject> getMessages() {
+        return messages;
+    }
+
+    public void setActionResult(T actionResult) {
+        this.actionResult = actionResult;
+    }
+
+    public void setMessages(Map<String, JSONObject> messages) {
+        this.messages = messages;
+    }
+
+    public void addMessage(String topic, JSONObject message) {
+        messages.put(topic, message);
+    }
+
+}

--- a/src/main/java/org/opengis/cite/sta10/receiveUpdatesViaMQTT/MqttHelper.java
+++ b/src/main/java/org/opengis/cite/sta10/receiveUpdatesViaMQTT/MqttHelper.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2016 Open Geospatial Consortium.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opengis.cite.sta10.receiveUpdatesViaMQTT;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import org.json.JSONObject;
+import org.opengis.cite.sta10.util.EntityType;
+import org.testng.Assert;
+
+/**
+ *
+ * @author jab
+ */
+public class MqttHelper {
+
+    private static final String MQTT_TOPIC_PREFIX = "v1.0/";
+    private final String mqttServerUri;
+    private final long mqttTimeout;
+
+    public MqttHelper(String mqttServerUri, long mqttTimeout) {
+        this.mqttServerUri = mqttServerUri;
+        this.mqttTimeout = mqttTimeout;
+    }
+
+    public <T> MqttBatchResult<T> executeRequests(Callable<T> action, String... topics) {
+        MqttBatchResult<T> result = new MqttBatchResult<>(topics.length);
+        Map<String, Future<JSONObject>> tempResult = new HashMap<>(topics.length);
+        ExecutorService executor = Executors.newFixedThreadPool(topics.length);
+        try {
+            for (String topic : topics) {
+                MqttListener listener = new MqttListener(mqttServerUri, topic);
+                listener.connect();
+                tempResult.put(topic, executor.submit(listener));
+            }
+            try {
+                result.setActionResult(action.call());
+            } catch (Exception ex) {
+                Assert.fail("Error executing : " + ex.getMessage(), ex);
+            }
+            executor.shutdown();
+            if (!executor.awaitTermination(mqttTimeout, TimeUnit.MILLISECONDS)) {
+                executor.shutdownNow();
+            }
+            for (Map.Entry<String, Future<JSONObject>> entry : tempResult.entrySet()) {
+                result.addMessage(entry.getKey(), entry.getValue().get());
+            }
+        } catch (InterruptedException | ExecutionException ex) {
+            Assert.fail("Error subcribing to MQTT.", ex);
+        } finally {
+            executor.shutdownNow();
+        }
+        return result;
+    }
+
+    public static List<String> getRelativeTopicsForEntity(EntityType entityType, Map<EntityType, Long> ids) {
+        List<String> result = new ArrayList<>();
+        switch (entityType) {
+            case THING:
+                result.add(getTopic(EntityType.DATASTREAM, ids) + "/Thing");
+                result.add(getTopic(EntityType.OBSERVATION, ids) + "/Datastream/Thing");
+                result.add(getTopic(EntityType.HISTORICAL_LOCATION, ids) + "/Thing");
+                break;
+            case LOCATION:
+                break;
+            case SENSOR:
+                result.add(getTopic(EntityType.DATASTREAM, ids) + "/Sensor");
+                result.add(getTopic(EntityType.OBSERVATION, ids) + "/Datastream/Sensor");
+                break;
+            case OBSERVED_PROPERTY:
+                result.add(getTopic(EntityType.DATASTREAM, ids) + "/ObservedProperty");
+                result.add(getTopic(EntityType.OBSERVATION, ids) + "/Datastream/ObservedProperty");
+                break;
+            case FEATURE_OF_INTEREST:
+                result.add(getTopic(EntityType.OBSERVATION, ids) + "/FeatureOfInterest");
+                break;
+            case DATASTREAM:
+                result.add(getTopic(EntityType.OBSERVATION, ids) + "/Datastream");
+                break;
+            case OBSERVATION:
+                break;
+            case HISTORICAL_LOCATION:
+                break;
+            default:
+                throw new IllegalArgumentException("Unknown EntityType '" + entityType.toString() + "'");
+        }
+        return result;
+    }
+
+    public static List<String> getRelativeTopicsForEntitySet(EntityType entityType, Map<EntityType, Long> ids) {
+        List<String> result = new ArrayList<>();
+        switch (entityType) {
+            case THING:
+                result.add(getTopic(EntityType.LOCATION, ids) + "/Things");
+                break;
+            case LOCATION:
+                result.add(getTopic(EntityType.THING, ids) + "/Locations");
+                result.add(getTopic(EntityType.DATASTREAM, ids) + "/Thing/Locations");
+                result.add(getTopic(EntityType.HISTORICAL_LOCATION, ids) + "/Thing/Locations");
+                break;
+            case SENSOR:
+                break;
+            case OBSERVED_PROPERTY:
+                break;
+            case FEATURE_OF_INTEREST:
+                break;
+            case DATASTREAM:
+                result.add(getTopic(EntityType.THING, ids) + "/Datastreams");
+                result.add(getTopic(EntityType.HISTORICAL_LOCATION, ids) + "/Thing/Datastreams");
+                result.add(getTopic(EntityType.SENSOR, ids) + "/Datastreams");
+                result.add(getTopic(EntityType.OBSERVED_PROPERTY, ids) + "/Datastreams");
+                break;
+            case OBSERVATION:
+                result.add(getTopic(EntityType.DATASTREAM, ids) + "/Observations");
+                break;
+            case HISTORICAL_LOCATION:
+                result.add(getTopic(EntityType.THING, ids) + "/HistoricalLocations");
+                result.add(getTopic(EntityType.DATASTREAM, ids) + "/Thing/HistoricalLocations");
+                result.add(getTopic(EntityType.LOCATION, ids) + "/HistoricalLocations");
+                break;
+            default:
+                throw new IllegalArgumentException("Unknown EntityType '" + entityType.toString() + "'");
+        }
+        return result;
+    }
+
+    public static String getTopic(EntityType entityType, List<String> selectedProperties) {
+        return getTopic(entityType) + "?$select=" + selectedProperties.stream().collect(Collectors.joining(","));
+    }
+
+    public static String getTopic(EntityType entityType, long id, String property) {
+        return getTopic(entityType) + "(" + id + ")/" + property;
+    }
+
+    public static String getTopic(EntityType entityType, long id) {
+        return getTopic(entityType) + "(" + id + ")";
+    }
+
+    public static String getTopic(EntityType entityType) {
+        switch (entityType) {
+            case THING:
+                return MQTT_TOPIC_PREFIX + "Things";
+            case LOCATION:
+                return MQTT_TOPIC_PREFIX + "Locations";
+            case SENSOR:
+                return MQTT_TOPIC_PREFIX + "Sensors";
+            case OBSERVED_PROPERTY:
+                return MQTT_TOPIC_PREFIX + "ObservedProperties";
+            case FEATURE_OF_INTEREST:
+                return MQTT_TOPIC_PREFIX + "FeaturesOfInterest";
+            case DATASTREAM:
+                return MQTT_TOPIC_PREFIX + "Datastreams";
+            case OBSERVATION:
+                return MQTT_TOPIC_PREFIX + "Observations";
+            case HISTORICAL_LOCATION:
+                return MQTT_TOPIC_PREFIX + "HistoricalLocations";
+            default:
+                throw new IllegalArgumentException("Unknown EntityType '" + entityType.toString() + "'");
+        }
+    }
+
+    private static String getTopic(EntityType entityType, Map<EntityType, Long> ids) {
+        return getTopic(entityType, ids.get(entityType));
+    }
+
+}

--- a/src/main/java/org/opengis/cite/sta10/receiveUpdatesViaMQTT/MqttListener.java
+++ b/src/main/java/org/opengis/cite/sta10/receiveUpdatesViaMQTT/MqttListener.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2016 Open Geospatial Consortium.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.opengis.cite.sta10.receiveUpdatesViaMQTT;
+
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.eclipse.paho.client.mqttv3.IMqttActionListener;
+import org.eclipse.paho.client.mqttv3.IMqttDeliveryToken;
+import org.eclipse.paho.client.mqttv3.IMqttToken;
+import org.eclipse.paho.client.mqttv3.MqttAsyncClient;
+import org.eclipse.paho.client.mqttv3.MqttCallback;
+import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
+import org.eclipse.paho.client.mqttv3.MqttException;
+import org.eclipse.paho.client.mqttv3.MqttMessage;
+import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence;
+import org.json.JSONObject;
+import org.testng.Assert;
+
+/**
+ *
+ * @author jab
+ */
+public class MqttListener implements Callable<JSONObject> {
+
+    private final static String CLIENT_ID = "STA-test_suite";
+    private static final int QOS = 2;
+
+    private final CountDownLatch barrier;
+    private final String topic;
+    private final String mqttServerUri;
+
+    private MqttAsyncClient mqttClient;
+    private JSONObject result;
+
+    public MqttListener(String mqttServer, String topic) {
+        this.mqttServerUri = mqttServer;
+        this.topic = topic;
+        barrier = new CountDownLatch(1);
+    }
+
+    public void connect() {
+        try {
+            final CountDownLatch connectBarrier = new CountDownLatch(1);
+            mqttClient = new MqttAsyncClient(mqttServerUri, CLIENT_ID + "-" + topic + "-" + UUID.randomUUID(), new MemoryPersistence());
+            MqttConnectOptions connOpts = new MqttConnectOptions();
+            connOpts.setCleanSession(true);
+            mqttClient.connect(connOpts, new IMqttActionListener() {
+                @Override
+                public void onSuccess(IMqttToken asyncActionToken) {
+                    mqttClient.setCallback(new MqttCallback() {
+                        @Override
+                        public void connectionLost(Throwable thrwbl) {
+                            Assert.fail("MQTT connection lost.");
+                        }
+
+                        @Override
+                        public void messageArrived(String topic, MqttMessage mm) throws Exception {
+                            if (barrier.getCount() > 0) {
+                                result = new JSONObject(new String(mm.getPayload(), StandardCharsets.UTF_8));
+                                barrier.countDown();
+                            }
+                        }
+
+                        @Override
+                        public void deliveryComplete(IMqttDeliveryToken imdt) {
+                        }
+                    });
+                    try {
+                        mqttClient.subscribe(topic, QOS, null, new IMqttActionListener() {
+                            @Override
+                            public void onSuccess(IMqttToken imt) {
+                                connectBarrier.countDown();
+                            }
+
+                            @Override
+                            public void onFailure(IMqttToken imt, Throwable thrwbl) {
+                                Assert.fail("MQTT subscribe failed.", thrwbl);
+                            }
+                        });
+                    } catch (MqttException ex) {
+                        Assert.fail("Error MQTT subscribe.", ex);
+                    }
+                }
+
+                @Override
+                public void onFailure(IMqttToken asyncActionToken, Throwable exception) {
+                    Assert.fail("MQTT connect failed.", exception);
+                }
+            });
+            try {
+                connectBarrier.await();
+            } catch (InterruptedException ex) {
+                Logger.getLogger(Capability8Test.class.getName()).log(Level.SEVERE, null, ex);
+            }
+        } catch (MqttException ex) {
+            Assert.fail("Could not connect to MQTT server.", ex);
+        }
+    }
+
+    @Override
+    public JSONObject call() throws Exception {
+        try {
+            barrier.await();
+        } catch (InterruptedException ex) {
+            Assert.fail("waiting for MQTT events exceeded time limit.", ex);
+            throw ex;
+        } finally {
+            if (mqttClient != null) {
+                if (mqttClient.isConnected()) {
+                    mqttClient.unsubscribe(topic, null, new IMqttActionListener() {
+                        @Override
+                        public void onSuccess(IMqttToken imt) {
+                            try {
+                                mqttClient.disconnect(null, new IMqttActionListener() {
+                                    @Override
+                                    public void onSuccess(IMqttToken imt) {
+                                        try {
+                                            mqttClient.close();
+                                        } catch (MqttException ex) {
+                                            Assert.fail("Error closing MQTT connection.", ex);
+                                        }
+                                    }
+
+                                    @Override
+                                    public void onFailure(IMqttToken imt, Throwable thrwbl) {
+                                        try {
+                                            mqttClient.disconnectForcibly();
+                                            mqttClient.close();
+                                        } catch (MqttException ex) {
+                                            Assert.fail("Error disconnecting MQTT.", ex);
+                                        }
+                                    }
+                                });
+                            } catch (MqttException ex) {
+                                Assert.fail("Error Error disconnecting from MQTT", ex);
+                            }
+                        }
+
+                        @Override
+                        public void onFailure(IMqttToken imt, Throwable thrwbl) {
+                            try {
+                                mqttClient.disconnect(null, new IMqttActionListener() {
+                                    @Override
+                                    public void onSuccess(IMqttToken imt) {
+                                        try {
+                                            mqttClient.close();
+                                        } catch (MqttException ex) {
+                                            Assert.fail("Error closing MQTT connection.", ex);
+                                        }
+                                    }
+
+                                    @Override
+                                    public void onFailure(IMqttToken imt, Throwable thrwbl) {
+                                        try {
+                                            mqttClient.disconnectForcibly();
+                                            mqttClient.close();
+                                        } catch (MqttException ex) {
+                                            Assert.fail("Error disconnecting MQTT.", ex);
+                                        }
+                                    }
+                                });
+                            } catch (MqttException ex) {
+                                Assert.fail("Error Error disconnecting from MQTT", ex);
+                            }
+                        }
+                    });
+
+                }
+            }
+        }
+        return result;
+    }
+}

--- a/src/main/java/org/opengis/cite/sta10/receiveUpdatesViaMQTT/package-info.java
+++ b/src/main/java/org/opengis/cite/sta10/receiveUpdatesViaMQTT/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Conformance Level 8 includes receiving updates from MQTT via subscription.
+ *
+ * @see <a
+ * href="http://www.w3.org/TR/html5/infrastructure.html#conformance-classes">HTML5 - Conformance classes</a>
+ */
+package org.opengis.cite.sta10.receiveUpdatesViaMQTT;

--- a/src/main/java/org/opengis/cite/sta10/util/EntityRelations.java
+++ b/src/main/java/org/opengis/cite/sta10/util/EntityRelations.java
@@ -4,6 +4,7 @@ package org.opengis.cite.sta10.util;
  * List of the entity relations for each entity type.
  */
 public class EntityRelations {
+
     /**
      * List of entity relations for Thing entity.
      */
@@ -37,15 +38,63 @@ public class EntityRelations {
      */
     public static final String[] FEATURE_OF_INTEREST_RELATIONS = {"Observations"};
 
+    public static EntityType getEntityTypeOfRelation(String relation) {
+        switch (relation.toLowerCase()) {
+            case "datastream":
+            case "datastreams":
+                return EntityType.DATASTREAM;
+            case "location":
+            case "locations":
+                return EntityType.LOCATION;
+            case "historicallocations":
+                return EntityType.HISTORICAL_LOCATION;
+            case "thing":
+            case "things":
+                return EntityType.THING;
+            case "sensor":
+                return EntityType.SENSOR;
+            case "observedproperty":
+                return EntityType.OBSERVED_PROPERTY;
+            case "observations":
+                return EntityType.OBSERVATION;
+            case "featureofinterest":
+                return EntityType.FEATURE_OF_INTEREST;
+        }
+        throw new IllegalArgumentException("Unknown relation.");
+    }
+
+    public static String getRootEntitySet(EntityType entityType) {
+        switch (entityType) {
+            case THING:
+                return "Things";
+            case LOCATION:
+                return "Locations";
+            case FEATURE_OF_INTEREST:
+                return "FeaturesOfInterest";
+            case OBSERVED_PROPERTY:
+                return "ObservedProperties";
+            case HISTORICAL_LOCATION:
+                return "HistoricalLocations";
+            case SENSOR:
+                return "Sensors";
+            case DATASTREAM:
+                return "Datastreams";
+            case OBSERVATION:
+                return "Observations";
+            default:
+                break;
+        }
+        return null;
+    }
 
     /**
      * Returning the list of entity relations for the given entityType.
+     *
      * @param entityType The type of entity from EntityType enum
      * @return List of all entity relations for the given entityType
      */
     public static String[] getRelationsListFor(EntityType entityType) {
-        switch (entityType)
-        {
+        switch (entityType) {
             case THING:
                 return THING_RELATIONS;
             case LOCATION:
@@ -70,6 +119,7 @@ public class EntityRelations {
 
     /**
      * Returning the list of entity relations for the given entity name.
+     *
      * @param name The type of entity in String format
      * @return List of all entity relations for the given entity
      */

--- a/src/main/resources/org/opengis/cite/sta10/testng.xml
+++ b/src/main/resources/org/opengis/cite/sta10/testng.xml
@@ -1,27 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suite name="${ets-code}-${version}" verbose="0" configfailurepolicy="continue">
-  <parameter name="iut"  value=""/>
-  <parameter name="ics"  value=""/>
+    <parameter name="iut"  value=""/>
+    <parameter name="ics"  value=""/>
 
-  <listeners>
-    <listener class-name="org.opengis.cite.sta10.TestRunListener" />
-    <listener class-name="org.opengis.cite.sta10.SuiteFixtureListener" />
-    <listener class-name="org.opengis.cite.sta10.TestFailureListener" />
-  </listeners>
+    <listeners>
+        <listener class-name="org.opengis.cite.sta10.TestRunListener" />
+        <listener class-name="org.opengis.cite.sta10.SuiteFixtureListener" />
+        <listener class-name="org.opengis.cite.sta10.TestFailureListener" />
+    </listeners>
 
-  <test name="Conformance Level 1">
-    <packages>
-      <package name="org.opengis.cite.sta10.sensingCore" />
-    </packages>
-  </test>
-  <test name="Conformance Level 2">
-    <packages>
-      <package name="org.opengis.cite.sta10.createUpdateDelete" />
-    </packages>
-  </test>
-  <test name="Conformance Level 3">
-    <packages>
-      <package name="org.opengis.cite.sta10.filteringExtension" />
-    </packages>
-  </test>
+    <test name="Conformance Level 1">
+        <packages>
+            <package name="org.opengis.cite.sta10.sensingCore" />
+        </packages>
+    </test>
+    <test name="Conformance Level 2">
+        <packages>
+            <package name="org.opengis.cite.sta10.createUpdateDelete" />
+        </packages>
+    </test>
+    <test name="Conformance Level 3">
+        <packages>
+            <package name="org.opengis.cite.sta10.filteringExtension" />
+        </packages>
+    </test>
+    <test name="Conformance Level 8">
+        <packages>
+            <package name="org.opengis.cite.sta10.receiveUpdatesViaMQTT" />
+        </packages>
+    </test>
 </suite>


### PR DESCRIPTION
This pull request implements the tests for receiving updates via MQTT as described in the SensorThings API [specification](http://docs.opengeospatial.org/is/15-078r6/15-078r6.html#89) including

- Subscribing to an entity set while inserting (POST) and updating (PUT, PATCH) entities for each entity type
- Subscribing to an entity set with multiple selected properties while inserting (POST) and updating (PUT, PATCH) entities for each entity type
- Subscribing to an entity set using different topics while inserting (POST) and updating (PUT, PATCH) entities for each entity type
- Subscribing to an entity while updating (PUT, PATCH) it for each entity type
- Subscribing to an entity using different topics while updating (PUT, PATCH) it for each entity type
- Subscribing to a property of an entity while updating (PUT, PATCH) it for each entity type and each propery (exlucing navigation properties)
- Subscribing to multiple entity set while doing a deep insert for every entity type possible

Two new properties were added to the properties file

- **mqtt_server** defines the address of the MQTT server
- **mqtt_timeout** defines the time in milliseconds a test case waits to receive an MQTT message

@bertt This might be of interest for you as you were interested in further tests https://github.com/opengeospatial/ets-sta10/issues/6